### PR TITLE
Add repo export import functionality in git test clients

### DIFF
--- a/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClient.kt
+++ b/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClient.kt
@@ -1,16 +1,21 @@
 package org.octopusden.octopus.infrastructure.common.test
 
+import java.io.File
+import java.nio.file.Files
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.errors.RefNotFoundException
 import org.eclipse.jgit.api.errors.TransportException
 import org.eclipse.jgit.lib.ConfigConstants.CONFIG_BRANCH_SECTION
+import org.eclipse.jgit.transport.URIish
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 import org.octopusden.octopus.infrastructure.common.test.dto.ChangeSet
 import org.octopusden.octopus.infrastructure.common.test.dto.NewChangeSet
 import org.slf4j.Logger
-import java.nio.file.Files
-import java.util.UUID
-import java.util.concurrent.TimeUnit
 
 
 abstract class BaseTestClient(username: String, password: String) : TestClient {
@@ -97,6 +102,74 @@ abstract class BaseTestClient(username: String, password: String) : TestClient {
         }
     }
 
+    override fun exportRepository(vcsUrl: String, zip: File) {
+        val git = repositories[vcsUrl]
+            ?: throw IllegalArgumentException("Repository $vcsUrl does not exist, can not export")
+        val projectRepo = parseUrl(vcsUrl)
+        getLog().info("Export VCS repository: '$projectRepo'")
+        val repository = git.repository.directory
+        ZipOutputStream(zip.outputStream()).use { zipOutputStream ->
+            repository.walkTopDown().forEach { file ->
+                if (file != repository) {
+                    zipOutputStream.putNextEntry(
+                        ZipEntry(
+                            repository.toPath().relativize(file.toPath()).toString() +
+                                    if (file.isDirectory) "/" else ""
+                        )
+                    )
+                    if (file.isFile) {
+                        file.inputStream().use { it.copyTo(zipOutputStream) }
+                    }
+                    zipOutputStream.closeEntry()
+                }
+            }
+        }
+    }
+
+    override fun importRepository(vcsUrl: String, zip: File) {
+        if (repositories.contains(vcsUrl)) {
+            throw IllegalArgumentException("Repository $vcsUrl exists already, can not import")
+        }
+        val projectRepo = parseUrl(vcsUrl)
+        getLog().info("Import VCS repository: '$projectRepo'")
+        createRepository(projectRepo)
+        val repositoryDir = Files.createTempDirectory("TestClient_")
+        val repository = repositoryDir.resolve(".git").also { Files.createDirectory(it) }
+        ZipInputStream(zip.inputStream()).use { zipInputStream ->
+            var entry = zipInputStream.nextEntry
+            while (entry != null) {
+                if (entry.isDirectory) {
+                    Files.createDirectory(repository.resolve(entry.name.trimEnd('/')))
+                } else {
+                    repository.resolve(entry.name).toFile().outputStream().use {
+                        zipInputStream.copyTo(it)
+                    }
+                }
+                entry = zipInputStream.nextEntry
+            }
+        }
+        val git = Git.open(repositoryDir.toFile())
+        git.remoteList().call().forEach {
+            git.remoteRemove()
+                .setRemoteName(it.name)
+                .call()
+        }
+        git.remoteAdd()
+            .setName("origin")
+            .setUri(URIish(convertSshToHttp(vcsUrl)))
+            .call()
+        retryableExecution {
+            git.push()
+                .setCredentialsProvider(jgitCredentialsProvider)
+                .setPushAll()
+                .setPushTags()
+                .call()
+        }
+        val sha = git.log().call().first { it.fullMessage == INITIAL_COMMIT_MESSAGE }.id.name
+        wait(waitMessage = "Wait commit='$sha' is accessible") { checkCommit(projectRepo, sha) }
+        repositories[vcsUrl] = git
+    }
+
     override fun clearData() {
         repositories.entries
             .forEach { (vcsUrl, git) ->
@@ -105,7 +178,6 @@ abstract class BaseTestClient(username: String, password: String) : TestClient {
                 git.repository
                     .directory
                     .deleteRecursively()
-
                 val projectRepo = parseUrl(vcsUrl)
                 getLog().debug("Delete VCS repository: '$projectRepo'")
                 deleteRepository(projectRepo)
@@ -140,28 +212,28 @@ abstract class BaseTestClient(username: String, password: String) : TestClient {
         val branches = git.branchList().call()
 
         if (branches.isEmpty()) {
-            getLog().debug("Empty repository, prepare 'master'")
+            getLog().debug("Empty repository, prepare '$DEFAULT_BRANCH'")
             parent?.let { parentValue ->
                 throw IllegalArgumentException("Empty repository, parent must be unspecified, but is: '$parentValue'")
             }
             val config = git.repository.config
-            config.setString(CONFIG_BRANCH_SECTION, "master", "remote", "origin")
-            config.setString(CONFIG_BRANCH_SECTION, "master", "merge", "refs/heads/master")
+            config.setString(CONFIG_BRANCH_SECTION, DEFAULT_BRANCH, "remote", "origin")
+            config.setString(CONFIG_BRANCH_SECTION, DEFAULT_BRANCH, "merge", "refs/heads/$DEFAULT_BRANCH")
             config.save()
             retryableExecution {
                 git.commit()
-                    .setMessage("initial commit")
+                    .setMessage(INITIAL_COMMIT_MESSAGE)
                     .call()
             }
         }
 
-        if (branches.any { it.name == "refs/heads/$branch" } || branch == "master") {
+        if (branches.any { it.name == "refs/heads/$branch" } || branch == DEFAULT_BRANCH) {
             getLog().debug("Branch '$branch' exists")
             parent?.let { _ ->
                 throw IllegalArgumentException("Use parent only for branch creation, $branch exists")
             }
         } else {
-            getLog().debug("Create branch '$branch', parent '${parent ?: "master:head"}'")
+            getLog().debug("Create branch '$branch', parent '${parent ?: "$DEFAULT_BRANCH:head"}'")
             parent?.let { parentValue ->
                 gitCheckout(git, parentValue)
             }
@@ -218,5 +290,10 @@ abstract class BaseTestClient(username: String, password: String) : TestClient {
     protected data class ProjectRepo(val project: String, val repository: String) {
         val path: String
             get() = "$project/$repository"
+    }
+
+    companion object {
+        const val DEFAULT_BRANCH = "master"
+        const val INITIAL_COMMIT_MESSAGE = "initial commit"
     }
 }

--- a/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/TestClient.kt
+++ b/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/TestClient.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.infrastructure.common.test
 
+import java.io.File
 import org.octopusden.octopus.infrastructure.common.test.dto.ChangeSet
 import org.octopusden.octopus.infrastructure.common.test.dto.NewChangeSet
 
@@ -7,5 +8,7 @@ import org.octopusden.octopus.infrastructure.common.test.dto.NewChangeSet
 interface TestClient {
     fun commit(newChangeSet: NewChangeSet, parent: String? = null): ChangeSet
     fun tag(vcsUrl: String, commitId: String, tag: String)
+    fun exportRepository(vcsUrl: String, zip: File)
+    fun importRepository(vcsUrl: String, zip: File)
     fun clearData()
 }

--- a/test-client-test-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClientTest.kt
+++ b/test-client-test-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClientTest.kt
@@ -1,5 +1,6 @@
 package org.octopusden.octopus.infrastructure.common.test
 
+import java.io.File
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -11,12 +12,13 @@ import org.octopusden.octopus.infrastructure.common.test.dto.NewChangeSet
 private const val TAG = "test_tag"
 private const val PROJECT = "test_project"
 private const val REPOSITORY = "test-repository"
+private const val FEATURE_BRANCH = "feature"
+private const val DEVELOP_BRANCH = "develop"
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class BaseTestClientTest(
     private val testClient: TestClient, vcsFormatter: String
 ) {
-
     abstract fun getTags(project: String, repository: String): Collection<TestTag>
     abstract fun getCommits(project: String, repository: String, branch: String): Collection<TestCommit>
     abstract fun createPullRequestWithDefaultReviewers(
@@ -39,67 +41,85 @@ abstract class BaseTestClientTest(
     fun testCommit() {
         testClient.commit(
             NewChangeSet(
-                "master commit 1",
+                "${BaseTestClient.DEFAULT_BRANCH} commit 1",
                 vcsUrl,
-                "master"
+                BaseTestClient.DEFAULT_BRANCH
             )
         )
         testClient.commit(
             NewChangeSet(
-                "master commit 2",
+                "${BaseTestClient.DEFAULT_BRANCH} commit 2",
                 vcsUrl,
-                "master"
+                BaseTestClient.DEFAULT_BRANCH
             )
         )
         val firstDevelopCommitId = testClient.commit(
             NewChangeSet(
-                "develop commit 1",
+                "$DEVELOP_BRANCH commit 1",
                 vcsUrl,
-                "develop"
+                DEVELOP_BRANCH
             )
         )
         testClient.commit(
             NewChangeSet(
-                "develop commit 2",
+                "$DEVELOP_BRANCH commit 2",
                 vcsUrl,
-                "develop"
+                DEVELOP_BRANCH
             )
         )
         testClient.commit(
             NewChangeSet(
-                "feature commit 1",
+                "$FEATURE_BRANCH commit 1",
                 vcsUrl,
-                "feature"
+                FEATURE_BRANCH
             ),
             firstDevelopCommitId.id
         )
 
-        checkCommits("master", listOf("master commit 2", "master commit 1", "initial commit"))
         checkCommits(
-            "develop",
-            listOf("develop commit 2", "develop commit 1", "master commit 2", "master commit 1", "initial commit")
+            BaseTestClient.DEFAULT_BRANCH,
+            listOf(
+                "${BaseTestClient.DEFAULT_BRANCH} commit 2",
+                "${BaseTestClient.DEFAULT_BRANCH} commit 1",
+                BaseTestClient.INITIAL_COMMIT_MESSAGE
+            )
         )
         checkCommits(
-            "feature",
-            listOf("feature commit 1", "develop commit 1", "master commit 2", "master commit 1", "initial commit")
+            DEVELOP_BRANCH,
+            listOf(
+                "$DEVELOP_BRANCH commit 2",
+                "$DEVELOP_BRANCH commit 1",
+                "${BaseTestClient.DEFAULT_BRANCH} commit 2",
+                "${BaseTestClient.DEFAULT_BRANCH} commit 1",
+                BaseTestClient.INITIAL_COMMIT_MESSAGE
+            )
+        )
+        checkCommits(
+            FEATURE_BRANCH,
+            listOf(
+                "$FEATURE_BRANCH commit 1",
+                "$DEVELOP_BRANCH commit 1",
+                "${BaseTestClient.DEFAULT_BRANCH} commit 2",
+                "${BaseTestClient.DEFAULT_BRANCH} commit 1",
+                BaseTestClient.INITIAL_COMMIT_MESSAGE
+            )
         )
     }
 
     @Test
     fun testCommitBranchExistsAndParentException() {
         assertThrows<IllegalArgumentException> {
-            testClient.commit(NewChangeSet("message", vcsUrl, "develop"), "leftId")
+            testClient.commit(NewChangeSet("message", vcsUrl, DEVELOP_BRANCH), "leftId")
         }
-
-        val commitId = testClient.commit(NewChangeSet("message", vcsUrl, "develop")).id
+        val commitId = testClient.commit(NewChangeSet("message", vcsUrl, DEVELOP_BRANCH)).id
         assertThrows<IllegalArgumentException> {
-            testClient.commit(NewChangeSet("message", vcsUrl, "develop"), commitId)
+            testClient.commit(NewChangeSet("message", vcsUrl, DEVELOP_BRANCH), commitId)
         }
     }
 
     @Test
     fun testTag() {
-        val expectedId = testClient.commit(NewChangeSet("test tag commit", vcsUrl, "master")).id
+        val expectedId = testClient.commit(NewChangeSet("tag commit", vcsUrl, BaseTestClient.DEFAULT_BRANCH)).id
         testClient.tag(vcsUrl, expectedId, TAG)
         Assertions.assertEquals(TAG, getTags(PROJECT, REPOSITORY).first().displayId)
         Assertions.assertEquals(expectedId, getTags(PROJECT, REPOSITORY).first().commitId)
@@ -110,7 +130,7 @@ abstract class BaseTestClientTest(
         assertThrows<IllegalArgumentException> {
             testClient.tag(vcsUrl, "", TAG)
         }
-        testClient.commit(NewChangeSet("message", vcsUrl, "develop")).id
+        testClient.commit(NewChangeSet("message", vcsUrl, DEVELOP_BRANCH)).id
         assertThrows<IllegalArgumentException> {
             testClient.tag(vcsUrl, "left", TAG)
         }
@@ -118,20 +138,62 @@ abstract class BaseTestClientTest(
 
     @Test
     fun testPullRequest() {
-        val mainBranch = "master"
-        testClient.commit(NewChangeSet("initial commit", vcsUrl, mainBranch))
-        val featureBranch = "feature"
-        testClient.commit(NewChangeSet("feature commit", vcsUrl, featureBranch))
-
+        testClient.commit(
+            NewChangeSet(
+                "${BaseTestClient.DEFAULT_BRANCH} commit",
+                vcsUrl,
+                BaseTestClient.DEFAULT_BRANCH
+            )
+        )
+        testClient.commit(NewChangeSet("$FEATURE_BRANCH commit", vcsUrl, FEATURE_BRANCH))
         val pullRequest = createPullRequestWithDefaultReviewers(
             PROJECT,
             REPOSITORY,
-            featureBranch,
-            mainBranch,
+            FEATURE_BRANCH,
+            BaseTestClient.DEFAULT_BRANCH,
             "PR Title",
             "PR Description"
         )
         Assertions.assertTrue(pullRequest.id > 0)
+    }
+
+    @Test
+    fun testExportImport() {
+        testClient.commit(NewChangeSet("${BaseTestClient.DEFAULT_BRANCH} commit", vcsUrl, BaseTestClient.DEFAULT_BRANCH))
+        testClient.commit(NewChangeSet("$FEATURE_BRANCH commit", vcsUrl, FEATURE_BRANCH))
+        val tagCommitId = testClient.commit(NewChangeSet("tag commit", vcsUrl, BaseTestClient.DEFAULT_BRANCH)).id
+        testClient.tag(vcsUrl, tagCommitId, TAG)
+        val zip = File.createTempFile("TestClientTest", "zip").also { it.deleteOnExit() }
+        testClient.exportRepository(vcsUrl, zip)
+        testClient.clearData()
+        Assertions.assertThrows(Exception::class.java) {
+            getCommits(PROJECT, REPOSITORY, BaseTestClient.DEFAULT_BRANCH)
+        }
+        Assertions.assertThrows(Exception::class.java) {
+            getCommits(PROJECT, REPOSITORY, FEATURE_BRANCH)
+        }
+        Assertions.assertThrows(Exception::class.java) {
+            getTags(PROJECT, REPOSITORY)
+        }
+        testClient.importRepository(vcsUrl, zip)
+        checkCommits(
+            BaseTestClient.DEFAULT_BRANCH,
+            listOf(
+                "tag commit",
+                "${BaseTestClient.DEFAULT_BRANCH} commit",
+                BaseTestClient.INITIAL_COMMIT_MESSAGE
+            )
+        )
+        checkCommits(
+            FEATURE_BRANCH,
+            listOf(
+                "$FEATURE_BRANCH commit",
+                "${BaseTestClient.DEFAULT_BRANCH} commit",
+                BaseTestClient.INITIAL_COMMIT_MESSAGE
+            )
+        )
+        Assertions.assertEquals(TAG, getTags(PROJECT, REPOSITORY).first().displayId)
+        Assertions.assertEquals(tagCommitId, getTags(PROJECT, REPOSITORY).first().commitId)
     }
 
     private fun checkCommits(branch: String, expected: List<String>) {


### PR DESCRIPTION
В тестовых клиентах BitBucket/Gitlab/Gitea добавлена возможность выгружать и загружать репозитории. Это позволит упростить тесты в компонентах, использующих эти тестовые клиенты, за счет единоразовой подготовки тестового репозитория и переиспользования/перезаливки его перед каждым тестом.