### PR TITLE
Implement Gitea client get commits method from id to id

### DIFF
--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
@@ -4,7 +4,7 @@ import feign.Headers
 import feign.Param
 import feign.QueryMap
 import feign.RequestLine
-import java.util.*
+import java.util.Date
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BaseBitbucketEntity
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketAuthor
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketBranch

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
@@ -155,7 +155,7 @@ fun BitbucketClient.getCommits(
             )
         }).also { commits ->
             if (!commits.any { commit -> commit.parents.any { it.id == fromId } }) {
-                throw NotFoundException("Cannot find commit '$fromId' in commit graph for commit '$toId'")
+                throw NotFoundException("Cannot find commit '$fromId' in commit graph for commit '$toId' in '$projectKey:$repository'")
             }
         }
     }

--- a/bitbucket-test-client/src/main/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClient.kt
+++ b/bitbucket-test-client/src/main/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClient.kt
@@ -67,7 +67,7 @@ class BitbucketTestClient(
     }
 
     override fun checkCommit(projectRepo: ProjectRepo, sha: String) {
-        client.getCommits(projectRepo.project, projectRepo.repository, null, null, sha)
+        client.getCommits(projectRepo.project, projectRepo.repository, sha)
     }
 
     companion object {

--- a/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
+++ b/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
@@ -31,7 +31,7 @@ class BitbucketTestClientTest : BaseTestClientTest(
         client.getTags(project, repository).map { t -> t.toTestTag() }
 
     override fun getCommits(project: String, repository: String, branch: String) =
-        client.getCommits(project, repository, null, null, branch).map { c -> c.toTestCommit() }
+        client.getCommits(project, repository, branch).map { c -> c.toTestCommit() }
 
     override fun createPullRequestWithDefaultReviewers(
         project: String,
@@ -40,7 +40,7 @@ class BitbucketTestClientTest : BaseTestClientTest(
         targetBranch: String,
         title: String,
         description: String
-    ): TestPullRequest = client.createPullRequestWithDefaultReviewers(
+    ) = client.createPullRequestWithDefaultReviewers(
         project,
         repository,
         sourceBranch,

--- a/gitea-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/client/GiteaClient.kt
+++ b/gitea-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/client/GiteaClient.kt
@@ -172,7 +172,7 @@ fun GiteaClient.getCommits(
         }
     } while ((giteaResponse.hasMore ?: (giteaResponse.values.isNotEmpty())) && orphanedCommits.isNotEmpty())
     if (!sinceCommitFound) {
-        throw NotFoundException("Cannot find commit '$fromSha' in commit graph for commit '$toSha'")
+        throw NotFoundException("Cannot find commit '$fromSha' in commit graph for commit '$toSha' in '$organization:$repository'")
     }
     return entities
 }

--- a/gitea-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClient.kt
+++ b/gitea-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClient.kt
@@ -47,7 +47,7 @@ class GiteaTestClient(val url: String, val username: String, val password: Strin
         client.deleteRepository(projectRepo.project, projectRepo.repository)
 
     override fun checkCommit(projectRepo: ProjectRepo, sha: String) {
-        client.getCommits(projectRepo.project, projectRepo.repository, null, sha)
+        client.getCommits(projectRepo.project, projectRepo.repository, sha)
     }
 
     private fun createOrganizationIfNotExist(organization: String) {

--- a/gitea-test-client/src/test/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClientTest.kt
+++ b/gitea-test-client/src/test/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClientTest.kt
@@ -25,11 +25,11 @@ class GiteaTestClientTest :
         override fun getAuth(): CredentialProvider = StandardBasicCredCredentialProvider(USER, PASSWORD)
     })
 
-    override fun getTags(project: String, repository: String): Collection<TestTag> =
+    override fun getTags(project: String, repository: String) =
         client.getTags(project, repository).map { t -> t.toTestTag() }
 
-    override fun getCommits(project: String, repository: String, branch: String): Collection<TestCommit> =
-        client.getCommits(project, repository, null, branch).map { c -> c.toTestCommit() }
+    override fun getCommits(project: String, repository: String, branch: String) =
+        client.getCommits(project, repository, branch).map { c -> c.toTestCommit() }
 
     override fun createPullRequestWithDefaultReviewers(
         project: String,
@@ -38,8 +38,7 @@ class GiteaTestClientTest :
         targetBranch: String,
         title: String,
         description: String
-    ): TestPullRequest =
-        client.createPullRequestWithDefaultReviewers(
+    ) = client.createPullRequestWithDefaultReviewers(
             project,
             repository,
             sourceBranch,

--- a/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClient.kt
+++ b/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClient.kt
@@ -123,9 +123,7 @@ abstract class BaseTestClient(username: String, password: String) : TestClient {
         retryableExecution {
             git.push().setCredentialsProvider(jgitCredentialsProvider).setPushAll().setPushTags().call()
         }
-        val commitId = git.log().call().first {
-            it.fullMessage == INITIAL_COMMIT_MESSAGE
-        }.id.name
+        val commitId = git.log().call().first().id.name
         wait(waitMessage = "Wait commit '$commitId' is accessible") {
             checkCommit(projectRepo, commitId)
         }


### PR DESCRIPTION
Also:
* Fix Gitea client get commits method since date to id (filtration should be the same as in Bitbucket client)
* Split/overload Bitbucket client get commits method (since/sinceDate)
* Add "from id is in graph" check in Bitbucket client get commits method
* Enhance Gitea client error processing (Gitea getCommit returns 500 instead of 404 when commit does not found)
* Add logging of number of retrieved pages