### PR TITLE
Enhance url parsing in test clients

### DIFF
--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketCommitIdValidator.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketCommitIdValidator.kt
@@ -1,13 +1,14 @@
 package org.octopusden.octopus.infrastructure.bitbucket.client
 
 import feign.Param.Expander
+import org.octopusden.octopus.infrastructure.bitbucket.client.exception.InvalidCommitIdException
 
 class BitbucketCommitIdValidator : Expander {
     override fun expand(value: Any?) =
         if (value is String && COMMIT_ID_REGEX matches value) {
             value
         } else {
-            throw IllegalArgumentException("'$value' is not valid BitBucket commit id")
+            throw InvalidCommitIdException("'$value' is not valid BitBucket commit id")
         }
 
     companion object {

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/exception/InvalidCommitIdException.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/exception/InvalidCommitIdException.kt
@@ -1,0 +1,3 @@
+package org.octopusden.octopus.infrastructure.bitbucket.client.exception
+
+class InvalidCommitIdException(message: String) : BitbucketClientException(message)

--- a/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
+++ b/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
@@ -10,6 +10,7 @@ import org.octopusden.octopus.infrastructure.bitbucket.client.createPullRequestW
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCommit
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketPullRequest
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketTag
+import org.octopusden.octopus.infrastructure.bitbucket.client.exception.InvalidCommitIdException
 import org.octopusden.octopus.infrastructure.bitbucket.client.getCommits
 import org.octopusden.octopus.infrastructure.bitbucket.client.getTags
 import org.octopusden.octopus.infrastructure.common.test.BaseTestClientTest
@@ -51,7 +52,7 @@ class BitbucketTestClientTest : BaseTestClientTest(
 
     @Test
     fun testGetCommitInvalidId() {
-        Assertions.assertThrowsExactly(IllegalArgumentException::class.java) {
+        Assertions.assertThrowsExactly(InvalidCommitIdException::class.java) {
             client.getCommit("projectKey", "repository", "bug/fix")
         }
     }

--- a/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
+++ b/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
@@ -19,7 +19,7 @@ private const val USER = "admin"
 private const val PASSWORD = "admin"
 
 class BitbucketTestClientTest : BaseTestClientTest(
-    BitbucketTestClient(HOST, USER, PASSWORD), "ssh://git@$HOST/%s/%s.git"
+    BitbucketTestClient("http://$HOST", USER, PASSWORD), "ssh://git@$HOST/%s/%s.git"
 ) {
 
     private val client = BitbucketClassicClient(object : BitbucketClientParametersProvider {


### PR DESCRIPTION
Необходимость обновить тестовые клиенты обнаружена в процессе изменениями в VCS Facade (https://github.com/octopusden/octopus-vcs-facade/pull/26).

Текущие проблемы:
* Для gitea валидными vcsUrl (ssh) могут являться url'ы с разными разделителями (двоеточие и слеш), а тестовые клиенты используют строковое представление vcsUrl как ключ для map
* Отсутствует проверка, что в vcsUrl (ssh) указан host, который используется при инициализации тестового клиента

Для исправления необходимо:
* Поправить методы parseUrl в тестовых клиентах по аналогии с VCS Facade (методы toProjectAndRepository/toOrganizationAndRepository/etc.)
* В методах convertSshToHttp и при регистрации репозитория использовать полученные в parseUrl значения

Дополнительно необходимо:
* Дать возможность не добавлять префикс ssh:// для vcsUrl в тестовых клиентах
* Поменять исключение в BitBucket клиенте на бизнес-специфичное в BitbucketCommitIdValidator
* Инициализировать тестовый BitBucket клиент от http url (как все остальные тестовые клиенты), а не от хоста