### PR TITLE
Add ability to define vcs url host

### DIFF
--- a/bitbucket-test-client/src/main/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClient.kt
+++ b/bitbucket-test-client/src/main/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClient.kt
@@ -18,11 +18,11 @@ class BitbucketTestClient(
     url: String,
     username: String,
     password: String,
-    host: String? = null,
+    externalHost: String? = null,
     commitRetries: Int = 20,
     commitPingInterval: Long = 500,
     commitRaiseException: Boolean = true,
-) : BaseTestClient(url, username, password, host, commitRetries, commitPingInterval, commitRaiseException) {
+) : BaseTestClient(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException) {
     private val client: BitbucketClient = BitbucketClassicClient(object : BitbucketClientParametersProvider {
         override fun getApiUrl() = apiUrl
         override fun getAuth(): BitbucketCredentialProvider = BitbucketBasicCredentialProvider(username, password)

--- a/bitbucket-test-client/src/main/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClient.kt
+++ b/bitbucket-test-client/src/main/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClient.kt
@@ -14,23 +14,23 @@ import org.octopusden.octopus.infrastructure.common.test.BaseTestClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-
 class BitbucketTestClient(
     url: String,
     username: String,
     password: String,
+    host: String? = null,
     commitRetries: Int = 20,
-    commitPingIntervalMsec: Long = 500,
+    commitPingInterval: Long = 500,
     commitRaiseException: Boolean = true,
-) : BaseTestClient(url, username, password, commitRetries, commitPingIntervalMsec, commitRaiseException) {
+) : BaseTestClient(url, username, password, host, commitRetries, commitPingInterval, commitRaiseException) {
     private val client: BitbucketClient = BitbucketClassicClient(object : BitbucketClientParametersProvider {
-        override fun getApiUrl() = url
+        override fun getApiUrl() = apiUrl
         override fun getAuth(): BitbucketCredentialProvider = BitbucketBasicCredentialProvider(username, password)
     })
 
-    override val urlRegex = "(?:ssh://)?git@$host[:/]([^:/]+)/([^:/]+).git".toRegex()
+    override val vcsUrlRegex = "(?:ssh://)?git@$vcsUrlHost/([^/]+)/([^/]+).git".toRegex()
 
-    override fun Repository.getHttpUrl() = "http://$host/scm/${this.path}.git"
+    override fun Repository.getUrl() = "$apiUrl/scm/${this.path}.git"
 
     override fun getLog(): Logger = log
 
@@ -39,7 +39,7 @@ class BitbucketTestClient(
     }
 
     override fun createRepository(repository: Repository) {
-        log.debug("[$host] create repository '$repository'")
+        log.debug("[$vcsUrlHost] create repository '$repository'")
         try {
             client.getProject(repository.group)
         } catch (e: NotFoundException) {
@@ -49,12 +49,12 @@ class BitbucketTestClient(
     }
 
     override fun deleteRepository(repository: Repository) {
-        log.debug("[$host] delete repository '$repository'")
+        log.debug("[$vcsUrlHost] delete repository '$repository'")
         client.deleteRepository(repository.group, repository.name)
     }
 
     override fun checkCommit(repository: Repository, sha: String) {
-        log.debug("[$host] check commit '$sha' in repository '$repository'")
+        log.debug("[$vcsUrlHost] check commit '$sha' in repository '$repository'")
         client.getCommits(repository.group, repository.name, sha)
     }
 

--- a/bitbucket-test-client/src/main/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClient.kt
+++ b/bitbucket-test-client/src/main/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClient.kt
@@ -14,15 +14,42 @@ import org.octopusden.octopus.infrastructure.common.test.BaseTestClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class BitbucketTestClient(
-    url: String,
-    username: String,
-    password: String,
-    externalHost: String? = null,
-    commitRetries: Int = 20,
-    commitPingInterval: Long = 500,
-    commitRaiseException: Boolean = true,
-) : BaseTestClient(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException) {
+class BitbucketTestClient : BaseTestClient {
+    constructor(url: String, username: String, password: String) : super(url, username, password)
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        externalHost: String
+    ) : super(url, username, password, externalHost)
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        commitRetries: Int,
+        commitPingInterval: Long,
+        commitRaiseException: Boolean
+    ) : super(
+        url,
+        username,
+        password,
+        commitRetries = commitRetries,
+        commitPingInterval = commitPingInterval,
+        commitRaiseException = commitRaiseException
+    )
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        externalHost: String,
+        commitRetries: Int,
+        commitPingInterval: Long,
+        commitRaiseException: Boolean
+    ) : super(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException)
+
     private val client: BitbucketClient = BitbucketClassicClient(object : BitbucketClientParametersProvider {
         override fun getApiUrl() = apiUrl
         override fun getAuth(): BitbucketCredentialProvider = BitbucketBasicCredentialProvider(username, password)

--- a/gitea-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClient.kt
+++ b/gitea-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClient.kt
@@ -13,15 +13,42 @@ import org.octopusden.octopus.infrastructure.gitea.client.getOrganizations
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class GiteaTestClient(
-    url: String,
-    username: String,
-    password: String,
-    externalHost: String? = null,
-    commitRetries: Int = 20,
-    commitPingInterval: Long = 500,
-    commitRaiseException: Boolean = true,
-) : BaseTestClient(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException) {
+class GiteaTestClient : BaseTestClient {
+    constructor(url: String, username: String, password: String) : super(url, username, password)
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        externalHost: String
+    ) : super(url, username, password, externalHost)
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        commitRetries: Int,
+        commitPingInterval: Long,
+        commitRaiseException: Boolean
+    ) : super(
+        url,
+        username,
+        password,
+        commitRetries = commitRetries,
+        commitPingInterval = commitPingInterval,
+        commitRaiseException = commitRaiseException
+    )
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        externalHost: String,
+        commitRetries: Int,
+        commitPingInterval: Long,
+        commitRaiseException: Boolean
+    ) : super(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException)
+
     private val client = GiteaClassicClient(object : ClientParametersProvider {
         override fun getApiUrl(): String = apiUrl
         override fun getAuth(): CredentialProvider = StandardBasicCredCredentialProvider(username, password)

--- a/gitea-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClient.kt
+++ b/gitea-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClient.kt
@@ -17,18 +17,19 @@ class GiteaTestClient(
     url: String,
     username: String,
     password: String,
+    host: String? = null,
     commitRetries: Int = 20,
     commitPingInterval: Long = 500,
     commitRaiseException: Boolean = true,
-) : BaseTestClient(url, username, password, commitRetries, commitPingInterval, commitRaiseException) {
+) : BaseTestClient(url, username, password, host, commitRetries, commitPingInterval, commitRaiseException) {
     private val client = GiteaClassicClient(object : ClientParametersProvider {
-        override fun getApiUrl(): String = url
+        override fun getApiUrl(): String = apiUrl
         override fun getAuth(): CredentialProvider = StandardBasicCredCredentialProvider(username, password)
     })
 
-    override val urlRegex = "(?:ssh://)?git@$host[:/]([^:/]+)/([^:/]+).git".toRegex()
+    override val vcsUrlRegex = "(?:ssh://)?git@$vcsUrlHost[:/]([^:/]+)/([^:/]+).git".toRegex()
 
-    override fun Repository.getHttpUrl() = "http://$host/${this.path}.git"
+    override fun Repository.getUrl() = "$apiUrl/${this.path}.git"
 
     override fun getLog(): Logger = log
 
@@ -37,7 +38,7 @@ class GiteaTestClient(
     }
 
     override fun createRepository(repository: Repository) {
-        log.debug("[$host] create repository '$repository'")
+        log.debug("[$vcsUrlHost] create repository '$repository'")
         try {
             client.getOrganization(repository.group)
         } catch (e: NotFoundException) {
@@ -47,12 +48,12 @@ class GiteaTestClient(
     }
 
     override fun deleteRepository(repository: Repository) {
-        log.debug("[$host] delete repository '$repository'")
+        log.debug("[$vcsUrlHost] delete repository '$repository'")
         client.deleteRepository(repository.group, repository.name)
     }
 
     override fun checkCommit(repository: Repository, sha: String) {
-        log.debug("[$host] check commit '$sha' in repository '$repository'")
+        log.debug("[$vcsUrlHost] check commit '$sha' in repository '$repository'")
         client.getCommits(repository.group, repository.name, sha)
     }
 

--- a/gitea-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClient.kt
+++ b/gitea-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitea/test/GiteaTestClient.kt
@@ -17,11 +17,11 @@ class GiteaTestClient(
     url: String,
     username: String,
     password: String,
-    host: String? = null,
+    externalHost: String? = null,
     commitRetries: Int = 20,
     commitPingInterval: Long = 500,
     commitRaiseException: Boolean = true,
-) : BaseTestClient(url, username, password, host, commitRetries, commitPingInterval, commitRaiseException) {
+) : BaseTestClient(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException) {
     private val client = GiteaClassicClient(object : ClientParametersProvider {
         override fun getApiUrl(): String = apiUrl
         override fun getAuth(): CredentialProvider = StandardBasicCredCredentialProvider(username, password)

--- a/gitlab-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitlab/test/GitlabTestClient.kt
+++ b/gitlab-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitlab/test/GitlabTestClient.kt
@@ -9,15 +9,42 @@ import org.octopusden.octopus.infrastructure.common.test.BaseTestClient
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class GitlabTestClient(
-    url: String,
-    username: String,
-    password: String,
-    externalHost: String? = null,
-    commitRetries: Int = 20,
-    commitPingInterval: Long = 500,
-    commitRaiseException: Boolean = true,
-) : BaseTestClient(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException) {
+class GitlabTestClient : BaseTestClient {
+    constructor(url: String, username: String, password: String) : super(url, username, password)
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        externalHost: String
+    ) : super(url, username, password, externalHost)
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        commitRetries: Int,
+        commitPingInterval: Long,
+        commitRaiseException: Boolean
+    ) : super(
+        url,
+        username,
+        password,
+        commitRetries = commitRetries,
+        commitPingInterval = commitPingInterval,
+        commitRaiseException = commitRaiseException
+    )
+
+    constructor(
+        url: String,
+        username: String,
+        password: String,
+        externalHost: String,
+        commitRetries: Int,
+        commitPingInterval: Long,
+        commitRaiseException: Boolean
+    ) : super(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException)
+
     private val client = GitLabApi.oauth2Login(apiUrl, username, password)
 
     override val vcsUrlRegex = "(?:ssh://)?git@$vcsUrlHost:((?:[^/]+/)+)([^/]+).git".toRegex()

--- a/gitlab-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitlab/test/GitlabTestClient.kt
+++ b/gitlab-test-client/src/main/kotlin/org/octopusden/octopus/infrastructure/gitlab/test/GitlabTestClient.kt
@@ -13,14 +13,14 @@ class GitlabTestClient(
     url: String,
     username: String,
     password: String,
-    vcsUrlHost: String? = null,
+    externalHost: String? = null,
     commitRetries: Int = 20,
     commitPingInterval: Long = 500,
     commitRaiseException: Boolean = true,
-) : BaseTestClient(url, username, password, vcsUrlHost, commitRetries, commitPingInterval, commitRaiseException) {
+) : BaseTestClient(url, username, password, externalHost, commitRetries, commitPingInterval, commitRaiseException) {
     private val client = GitLabApi.oauth2Login(apiUrl, username, password)
 
-    override val vcsUrlRegex = "(?:ssh://)?git@${this.vcsUrlHost}:((?:[^/]+/)+)([^/]+).git".toRegex()
+    override val vcsUrlRegex = "(?:ssh://)?git@$vcsUrlHost:((?:[^/]+/)+)([^/]+).git".toRegex()
 
     override fun Repository.getUrl() = "$apiUrl/${this.path}.git"
 

--- a/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClient.kt
+++ b/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClient.kt
@@ -21,7 +21,7 @@ abstract class BaseTestClient(
     url: String,
     username: String,
     password: String,
-    host: String?,
+    externalHost: String?,
     private val commitRetries: Int,
     private val commitPingInterval: Long,
     private val commitRaiseException: Boolean
@@ -29,7 +29,7 @@ abstract class BaseTestClient(
     private val repositories = mutableMapOf<Repository, Git>()
     private val jgitCredentialsProvider = UsernamePasswordCredentialsProvider(username, password)
     protected val apiUrl = url.trimEnd('/')
-    protected val vcsUrlHost = host?.lowercase() ?: apiUrl.lowercase().replace("^(https|http)://".toRegex(), "")
+    protected val vcsUrlHost = externalHost?.lowercase() ?: apiUrl.lowercase().replace("^(https|http)://".toRegex(), "")
     protected abstract val vcsUrlRegex: Regex
 
     private fun parseUrl(vcsUrl: String) = vcsUrlRegex.find(vcsUrl.lowercase())?.let { result ->

--- a/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClient.kt
+++ b/test-client-commons/src/main/kotlin/org/octopusden/octopus/infrastructure/common/test/BaseTestClient.kt
@@ -19,15 +19,16 @@ import org.slf4j.Logger
 
 abstract class BaseTestClient(
     url: String,
-    username: String,
-    password: String,
-    externalHost: String?,
-    private val commitRetries: Int,
-    private val commitPingInterval: Long,
-    private val commitRaiseException: Boolean
+    protected val username: String,
+    protected val password: String,
+    externalHost: String? = null,
+    private val commitRetries: Int = 20,
+    private val commitPingInterval: Long = 500,
+    private val commitRaiseException: Boolean = true
 ) : TestClient {
     private val repositories = mutableMapOf<Repository, Git>()
     private val jgitCredentialsProvider = UsernamePasswordCredentialsProvider(username, password)
+
     protected val apiUrl = url.trimEnd('/')
     protected val vcsUrlHost = externalHost?.lowercase() ?: apiUrl.lowercase().replace("^(https|http)://".toRegex(), "")
     protected abstract val vcsUrlRegex: Regex


### PR DESCRIPTION
Для упрощения перевода тестов на новые тестовые клиенты добавлена возможность переопределять хост для vcs url'ов. Это требуется когда тестовый клиент и тестируемый клиент имеют доступ к серверу git из разных сетей (например localhost и host.docker.internal).

Дополнительно: для удобства использования тестовых клиентов в java коде добавлена перегрузка конструкторов.