### PR TITLE
fix feign.FeignException in teamcityClient.getProject(1ST_LEVEL_PRJ)

### DIFF
--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityProject.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityProject.kt
@@ -3,7 +3,7 @@ package org.octopusden.octopus.infrastructure.teamcity.client.dto
 data class TeamcityProject(
     val id: String,
     val name: String,
-    val parentProjectId: String,
+    val parentProjectId: String? = null,
 //    val parentProjectName: String? = null,
 //    val archived: Boolean? = null,
 //    val virtual: Boolean? = null,


### PR DESCRIPTION
this prevents FeignException in  teamcityClient.getProject(prj) where prj is first level project,

```
Exception in thread "main" feign.FeignException: Instantiation of [simple type, class org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProject] value failed for JSON property parentProjectId due to missing (therefore NULL) value for creator parameter parentProjectId which is a non-nullable type
 at [Source: (BufferedReader); line: 1, column: 483] (through reference chain: org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProject["parentProject"]->org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProject["parentProjectId"]) reading GET https://teamcity/app/rest/2018.1/projects/id%3AFirstLevelPrj
	at feign.FeignException.errorReading(FeignException.java:167)
	at feign.InvocationContext.proceed(InvocationContext.java:42)
	at feign.ResponseHandler.decode(ResponseHandler.java:122)
	at feign.ResponseHandler.handleResponse(ResponseHandler.java:73)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:114)
	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:70)
	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:96)
	at com.sun.proxy.$Proxy8.getProject(Unknown Source)
	at org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClassicClient.getProject(TeamcityClassicClient.kt:45)
	at org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClientKt.getProject(TeamcityClient.kt:326)
	at com.tst.MainKt.main(Main.kt:20)
	at com.tst.MainKt.main(Main.kt)
```