### PR TITLE
Add support to get pull requests by user in Bitbucket Client

### DIFF
--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClassicClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClassicClient.kt
@@ -90,8 +90,8 @@ class BitbucketClassicClient(
     override fun getPullRequests(requestParams: Map<String, Any>) =
         client.getPullRequests(requestParams)
 
-    override fun getRepositoryFiles(projectKey: String, repository: String, at: String?, start: Int?, limit: Int?) =
-        client.getRepositoryFiles(projectKey, repository, at, start, limit)
+    override fun getRepositoryFiles(projectKey: String, repository: String, requestParams: Map<String, Any>) =
+        client.getRepositoryFiles(projectKey, repository, requestParams)
 
     override fun getRepositoryRawFileContent(projectKey: String, repository: String, filePath: String) =
         client.getRepositoryRawFileContent(projectKey, repository, filePath)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClassicClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClassicClient.kt
@@ -87,8 +87,8 @@ class BitbucketClassicClient(
     override fun getPullRequest(projectKey: String, repository: String, id: Long) =
         client.getPullRequest(projectKey, repository, id)
 
-    override fun getPullRequestsByUser(user: String?, start: Int?, limit: Int?, order: String?) =
-        client.getPullRequestsByUser(user, start, limit, order)
+    override fun getPullRequests(requestParams: Map<String, Any>) =
+        client.getPullRequests(requestParams)
 
     override fun getRepositoryFiles(projectKey: String, repository: String, at: String?, start: Int?, limit: Int?) =
         client.getRepositoryFiles(projectKey, repository, at, start, limit)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClassicClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClassicClient.kt
@@ -87,6 +87,9 @@ class BitbucketClassicClient(
     override fun getPullRequest(projectKey: String, repository: String, id: Long) =
         client.getPullRequest(projectKey, repository, id)
 
+    override fun getPullRequestsByUser(user: String?, start: Int?, limit: Int?, order: String?) =
+        client.getPullRequestsByUser(user, start, limit, order)
+
     override fun getRepositoryFiles(projectKey: String, repository: String, at: String?, start: Int?, limit: Int?) =
         client.getRepositoryFiles(projectKey, repository, at, start, limit)
 

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
@@ -180,9 +180,7 @@ interface BitbucketClient {
     fun getRepositoryFiles(
         @Param("projectKey") projectKey: String,
         @Param("repository") repository: String,
-        @Param("at") at: String?,
-        @Param("start") start: Int?,
-        @Param("limit") limit: Int?
+        @QueryMap requestParams: Map<String, Any>
     ): BitbucketEntityList<String>
 
     @RequestLine("GET $PROJECT_PATH/{projectKey}/repos/{repository}/raw/{filePath}")

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory
 
 private val _log: Logger = LoggerFactory.getLogger(BitbucketClient::class.java)
 
+const val DASHBOARD_PATH = "rest/api/1.0/dashboard"
 const val PROJECT_PATH = "rest/api/1.0/projects"
 const val REPO_PATH = "rest/api/1.0/repos"
 const val GIT_PROJECT_PATH = "/rest/git/1.0/projects"
@@ -167,6 +168,15 @@ interface BitbucketClient {
         @Param("repository") repository: String,
         @Param("id") id: Long
     ): BitbucketPullRequest
+
+    @RequestLine("GET $DASHBOARD_PATH/pull-requests?user={user}&start={start}&limit={limit}&order={order}")
+    @Headers("Content-Type: application/json")
+    fun getPullRequestsByUser(
+        @Param("user") user: String?,
+        @Param("start") start: Int?,
+        @Param("limit") limit: Int?,
+        @Param("order") order: String?,
+    ): BitbucketEntityList<BitbucketPullRequest>
 
     @RequestLine("GET $PROJECT_PATH/{projectKey}/repos/{repository}/files?at={at}&start={start}&limit={limit}")
     @Throws(NotFoundException::class)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
@@ -169,13 +169,10 @@ interface BitbucketClient {
         @Param("id") id: Long
     ): BitbucketPullRequest
 
-    @RequestLine("GET $DASHBOARD_PATH/pull-requests?user={user}&start={start}&limit={limit}&order={order}")
+    @RequestLine("GET $DASHBOARD_PATH/pull-requests")
     @Headers("Content-Type: application/json")
-    fun getPullRequestsByUser(
-        @Param("user") user: String?,
-        @Param("start") start: Int?,
-        @Param("limit") limit: Int?,
-        @Param("order") order: String?,
+    fun getPullRequests(
+        @QueryMap requestParams: Map<String, Any>
     ): BitbucketEntityList<BitbucketPullRequest>
 
     @RequestLine("GET $PROJECT_PATH/{projectKey}/repos/{repository}/files?at={at}&start={start}&limit={limit}")
@@ -308,6 +305,10 @@ fun BitbucketClient.getBranches(projectKey: String, repository: String) = execut
 fun BitbucketClient.getBranch(projectKey: String, repository: String, branch: String) =
     findBranch(projectKey, repository, branch)
         ?: throw NotFoundException("Branch '$branch' is not found in '$projectKey:$repository'")
+
+fun BitbucketClient.getPullRequests() = execute(
+    { parameters: Map<String, Any> -> getPullRequests(parameters) }
+)
 
 fun BitbucketClient.createPullRequestWithDefaultReviewers(
     projectKey: String,

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketBranch.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketBranch.kt
@@ -3,5 +3,6 @@ package org.octopusden.octopus.infrastructure.bitbucket.client.dto
 class BitbucketBranch(
     id: String,
     displayId: String,
-    latestCommit: String
-) : BitbucketRef(id, displayId, latestCommit, BitbucketRefType.BRANCH)
+    latestCommit: String,
+    repository: BitbucketRepository? = null
+) : BitbucketRef(id, displayId, latestCommit, BitbucketRefType.BRANCH, repository)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketPullRequest.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketPullRequest.kt
@@ -14,5 +14,5 @@ class BitbucketPullRequest(
     val createdDate: Date,
     val updatedDate: Date
 ) {
-    class BitbucketPullRequestUser(val user: BitbucketUser, val approved: Boolean)
+    class BitbucketPullRequestUser(val user: BitbucketUser, val approved: Boolean, val status: BitbucketPullRequestUserStatus)
 }

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketPullRequestUserStatus.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketPullRequestUserStatus.kt
@@ -1,0 +1,5 @@
+package org.octopusden.octopus.infrastructure.bitbucket.client.dto
+
+enum class BitbucketPullRequestUserStatus {
+    UNAPPROVED, NEEDS_WORK, APPROVED
+}

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketRef.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketRef.kt
@@ -17,7 +17,8 @@ abstract class BitbucketRef(
     val id: String,
     val displayId: String,
     val latestCommit: String,
-    val type: BitbucketRefType
+    val type: BitbucketRefType,
+    val repository: BitbucketRepository? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -26,6 +27,7 @@ abstract class BitbucketRef(
         if (displayId != other.displayId) return false
         if (latestCommit != other.latestCommit) return false
         if (type != other.type) return false
+        if (repository != other.repository) return false
         return true
     }
 
@@ -34,6 +36,7 @@ abstract class BitbucketRef(
         result = 31 * result + displayId.hashCode()
         result = 31 * result + latestCommit.hashCode()
         result = 31 * result + type.hashCode()
+        result = 31 * result + repository.hashCode()
         return result
     }
 }

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketTag.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketTag.kt
@@ -3,5 +3,6 @@ package org.octopusden.octopus.infrastructure.bitbucket.client.dto
 class BitbucketTag(
     id: String,
     displayId: String,
-    latestCommit: String
-) : BitbucketRef(id, displayId, latestCommit, BitbucketRefType.TAG)
+    latestCommit: String,
+    repository: BitbucketRepository? = null
+) : BitbucketRef(id, displayId, latestCommit, BitbucketRefType.TAG, repository)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketUser.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketUser.kt
@@ -1,3 +1,3 @@
 package org.octopusden.octopus.infrastructure.bitbucket.client.dto
 
-data class BitbucketUser(val name: String)
+data class BitbucketUser(val name: String, val displayName: String? = null)

--- a/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
+++ b/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
@@ -133,7 +133,7 @@ class BitbucketTestClientTest : BaseTestClientTest(
         client.getPullRequest(project, repository, index).toTestPullRequest()
 
     @Test
-    fun testGetPullRequestByUser(){
+    fun testGetPullRequests(){
         testClient.commit(
             NewChangeSet(
                 "${BaseTestClient.DEFAULT_BRANCH} commit",
@@ -161,7 +161,7 @@ class BitbucketTestClientTest : BaseTestClientTest(
             pr
         }
 
-        val pullRequests = client.getPullRequestsByUser(USER, null, null, "OLDEST")
+        val pullRequests = client.getPullRequests(mapOf("order" to "OLDEST"))
 
         Assertions.assertEquals(prBranches.size, pullRequests.size)
         Assertions.assertEquals(prBranches.size, pullRequests.values.size)

--- a/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
+++ b/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
@@ -81,7 +81,7 @@ class BitbucketTestClientTest : BaseTestClientTest(
                 BaseTestClient.DEFAULT_BRANCH,
             ), null, paths
         )
-        val response = client.getRepositoryFiles(PROJECT, REPOSITORY, BaseTestClient.DEFAULT_BRANCH,0, filesName.size)
+        val response = client.getRepositoryFiles(PROJECT, REPOSITORY, mapOf("at" to BaseTestClient.DEFAULT_BRANCH, "start" to 0, "limit" to filesName.size))
         Assertions.assertEquals(filesName.size, response.values.size)
         Assertions.assertTrue(response.values.containsAll(filesName))
     }
@@ -96,7 +96,7 @@ class BitbucketTestClientTest : BaseTestClientTest(
             ), null, null
         )
         Assertions.assertThrowsExactly(NotFoundException::class.java, {
-            client.getRepositoryFiles(PROJECT, REPOSITORY, "other_branch",0, 10)
+            client.getRepositoryFiles(PROJECT, REPOSITORY, mapOf("at" to "other_branch", "start" to 0, "limit" to 0))
         }, "Object \"other_branch\" does not exist in repository 'test-repository'")
     }
 


### PR DESCRIPTION
- Add support for retrieving [pull requests by user](https://developer.atlassian.com/server/bitbucket/rest/v904/api-group-dashboard/#api-api-latest-dashboard-pull-requests-get) in the Bitbucket Client.
- Update the response model to include fields (`repository`, `displayName`, `status`) from the REST API.