### PR TITLE
FIX:Property expiry is nullable

### DIFF
--- a/artifactory-client/src/main/kotlin/org/octopusden/octopus/infrastructure/artifactory/client/dto/Tokens.kt
+++ b/artifactory-client/src/main/kotlin/org/octopusden/octopus/infrastructure/artifactory/client/dto/Tokens.kt
@@ -3,5 +3,5 @@ package org.octopusden.octopus.infrastructure.artifactory.client.dto
 import java.util.Date
 
 data class Tokens(val tokens: List<Token>) {
-    data class Token(val subject: String, val issuer: String, val expiry: Date, val description: String?)
+    data class Token(val subject: String, val issuer: String, val expiry: Date?, val description: String?)
 }


### PR DESCRIPTION
`Exception in thread "main" feign.FeignException: Instantiation of [simple type, class org.octopusden.octopus.infrastructure.artifactory.client.dto.Tokens$Token] value failed for JSON property expiry due to missing (therefore NULL) value for creator parameter expiry which is a non-nullable type`