### PR TITLE
Added fields parameter to populate missing model fields.

### DIFF
--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClient.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClient.kt
@@ -58,6 +58,8 @@ class TeamcityClassicClient(
 
     override fun getBuildTypes() = client.getBuildTypes()
 
+    override fun getBuildTypesWithFields(fields: String) = client.getBuildTypesWithFields(fields)
+
     override fun getBuildTypes(project: ProjectLocator) = client.getBuildTypes(project)
     override fun deleteAgentRequirement(buildType: BuildTypeLocator, agentRequirementLocator: AgentRequirementLocator) =
         client.deleteAgentRequirement(buildType, agentRequirementLocator)

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClient.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClient.kt
@@ -81,6 +81,16 @@ interface TeamcityClient {
     @Headers("Accept: application/json")
     fun getBuildTypes(): TeamcityBuildTypes
 
+    /**
+     * Get all build types with the specified fields.
+     * Example: `fields=id,name,project(id,name),vcs-root-entries(id,name)`
+     */
+    @RequestLine("GET $REST/buildTypes?fields={fields}")
+    @Headers("Accept: application/json")
+    fun getBuildTypesWithFields(
+        @Param("fields") fields: String
+    ): TeamcityBuildTypes
+
     @RequestLine("GET $REST/projects/{locator}/buildTypes")
     @Headers("Accept: application/json")
     fun getBuildTypes(@Param("locator", expander = Locator::class) project: ProjectLocator): TeamcityBuildTypes

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityBuildType.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityBuildType.kt
@@ -22,5 +22,6 @@ data class TeamcityBuildType(
     val triggers: TeamcityTriggers? = null,
     @JsonProperty("snapshot-dependencies")
     val snapshotDependencies: TeamcitySnapshotDependencies? = null,
+    val paused: Boolean? = null,
 )
 


### PR DESCRIPTION
By default, the rest/buildTypes endpoint returns only attributes at the buildType level. This means that fields like paused and project in the response model are not populated unless they are explicitly specified in the fields parameter.