### PR TITLE
Enable Writable /var/lib/gitea on OKD for Gitea FT

### DIFF
--- a/okd/gitea.yaml
+++ b/okd/gitea.yaml
@@ -30,6 +30,8 @@ objects:
       labels:
         app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-gitea
     spec:
+      securityContext:
+        fsGroup: 1000
       restartPolicy: Never
       activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
       containers:


### PR DESCRIPTION
During Gitea server initialization on OKD, the container fails with:

> mkdir: can't create directory '/var/lib/gitea/git': Permission denied
/var/lib/gitea/git is not writable
docker setup failed

Added the fsGroup security context to allow write access to /var/lib/gitea.