### PR TITLE
Implement client for delete Bitbucket PR and branch

### DIFF
--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClassicClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClassicClient.kt
@@ -13,6 +13,8 @@ import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCreat
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCreatePullRequest
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCreateRepository
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCreateTag
+import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketDeleteBranch
+import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketDeletePullRequest
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketUpdateRepository
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.DefaultReviewersQuery
 
@@ -78,6 +80,9 @@ class BitbucketClassicClient(
     override fun getBranches(projectKey: String, repository: String, requestParams: Map<String, Any>) =
         client.getBranches(projectKey, repository, requestParams)
 
+    override fun deleteBranch(projectKey: String, repository: String, dto: BitbucketDeleteBranch) =
+        client.deleteBranch(projectKey, repository, dto)
+
     override fun getDefaultReviewers(projectKey: String, repository: String, query: DefaultReviewersQuery) =
         client.getDefaultReviewers(projectKey, repository, query)
 
@@ -89,6 +94,9 @@ class BitbucketClassicClient(
 
     override fun getPullRequests(requestParams: Map<String, Any>) =
         client.getPullRequests(requestParams)
+
+    override fun deletePullRequest(projectKey: String, repository: String, pullRequestId: String, dto: BitbucketDeletePullRequest) =
+        client.deletePullRequest(projectKey, repository, pullRequestId, dto)
 
     override fun getRepositoryFiles(projectKey: String, repository: String, requestParams: Map<String, Any>) =
         client.getRepositoryFiles(projectKey, repository, requestParams)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/BitbucketClient.kt
@@ -14,6 +14,8 @@ import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCreat
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCreatePullRequestReviewer
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCreateRepository
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketCreateTag
+import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketDeleteBranch
+import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketDeletePullRequest
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketEntityList
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketJiraCommit
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketProject
@@ -34,6 +36,7 @@ private val _log: Logger = LoggerFactory.getLogger(BitbucketClient::class.java)
 const val DASHBOARD_PATH = "rest/api/1.0/dashboard"
 const val PROJECT_PATH = "rest/api/1.0/projects"
 const val REPO_PATH = "rest/api/1.0/repos"
+const val BRANCH_PATH = "rest/branch-utils/1.0/projects"
 const val GIT_PROJECT_PATH = "/rest/git/1.0/projects"
 const val JIRA_ISSUES_PATH = "rest/jira/1.0/issues"
 const val DEFAULT_REVIEWERS_PATH = "rest/default-reviewers/1.0/projects"
@@ -146,6 +149,14 @@ interface BitbucketClient {
         @QueryMap requestParams: Map<String, Any>,
     ): BitbucketEntityList<BitbucketBranch>
 
+    @RequestLine("DELETE $BRANCH_PATH/{projectKey}/repos/{repository}/branches")
+    @Headers("Content-Type: application/json")
+    fun deleteBranch(
+        @Param("projectKey") projectKey: String,
+        @Param("repository") repository: String,
+        dto: BitbucketDeleteBranch
+    )
+
     @RequestLine("GET $DEFAULT_REVIEWERS_PATH/{projectKey}/repos/{repository}/reviewers")
     fun getDefaultReviewers(
         @Param("projectKey") projectKey: String,
@@ -163,6 +174,7 @@ interface BitbucketClient {
 
     @RequestLine("GET $PROJECT_PATH/{projectKey}/repos/{repository}/pull-requests/{id}")
     @Headers("Content-Type: application/json")
+    @Throws(NotFoundException::class)
     fun getPullRequest(
         @Param("projectKey") projectKey: String,
         @Param("repository") repository: String,
@@ -174,6 +186,15 @@ interface BitbucketClient {
     fun getPullRequests(
         @QueryMap requestParams: Map<String, Any>
     ): BitbucketEntityList<BitbucketPullRequest>
+
+    @RequestLine("DELETE $PROJECT_PATH/{projectKey}/repos/{repository}/pull-requests/{pullRequestId}")
+    @Headers("Content-Type: application/json")
+    fun deletePullRequest(
+        @Param("projectKey") projectKey: String,
+        @Param("repository") repository: String,
+        @Param("pullRequestId") pullRequestId: String,
+        dto: BitbucketDeletePullRequest
+    )
 
     @RequestLine("GET $PROJECT_PATH/{projectKey}/repos/{repository}/files?at={at}&start={start}&limit={limit}")
     @Throws(NotFoundException::class)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketDeleteBranch.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketDeleteBranch.kt
@@ -1,0 +1,5 @@
+package org.octopusden.octopus.infrastructure.bitbucket.client.dto
+
+data class BitbucketDeleteBranch(
+    val name: String
+)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketDeletePullRequest.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketDeletePullRequest.kt
@@ -1,0 +1,5 @@
+package org.octopusden.octopus.infrastructure.bitbucket.client.dto
+
+data class BitbucketDeletePullRequest(
+    val version: Int
+)

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketExceptionName.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketExceptionName.kt
@@ -36,6 +36,10 @@ enum class BitbucketExceptionName(
         "com.atlassian.bitbucket.content.NoSuchPathException",
         { message -> NotFoundException(message) }
     ),
+    NO_SUCH_PULL_REQUEST(
+        "com.atlassian.bitbucket.pull.NoSuchPullRequestException",
+        { message -> NotFoundException(message) }
+    ),
     OTHER("", { message -> IllegalStateException(message) });
 
     companion object {

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketPullRequest.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketPullRequest.kt
@@ -12,7 +12,8 @@ class BitbucketPullRequest(
     val toRef: BitbucketRef,
     val state: BitbucketPullRequestState,
     val createdDate: Date,
-    val updatedDate: Date
+    val updatedDate: Date,
+    val version: Int
 ) {
     class BitbucketPullRequestUser(val user: BitbucketUser, val approved: Boolean, val status: BitbucketPullRequestUserStatus)
 }


### PR DESCRIPTION
**Main changes:**

Implement Bitbucket client for:
- Delete Pull Request: https://developer.atlassian.com/server/bitbucket/rest/v904/api-group-pull-requests/#api-api-latest-projects-projectkey-repos-repositoryslug-pull-requests-pullrequestid-delete
- Delete Branch: https://developer.atlassian.com/server/bitbucket/rest/v904/api-group-repository/#api-branch-utils-latest-projects-projectkey-repos-repositoryslug-branches-delete 

**Additional changes:**
- Return `version` property in the `BitbucketPullRequest` response
- Use `NotFoundException` for not found `getPullRequest` response