### PR TITLE
Add field in TeamcityAddInvestigation and TeamcityInvestigation

### DIFF
--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityAddInvestigation.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityAddInvestigation.kt
@@ -3,6 +3,7 @@ package org.octopusden.octopus.infrastructure.teamcity.client.dto
 data class TeamcityAddInvestigation(
     val state: String,
     val assignee: TeamcityAssignee,
+    val assignment: TeamcityAssignment? = null,
     val scope: TeamcityScope,
     val target: TeamcityTarget,
     val resolution: TeamcityResolution

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityInvestigation.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityInvestigation.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.infrastructure.teamcity.client.dto
 
 data class TeamcityInvestigation(
+    val id: String? = null,
     val state: String,
     val assignee: TeamcityAssignee? = null,
     val assignment: TeamcityAssignment? = null

--- a/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
+++ b/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
@@ -21,6 +21,7 @@ import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAddInve
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAddInvestigationBuildTypes
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAgentRequirement
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAssignee
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAssignment
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityBuildTypes
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityCreateBuildType
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityCreateProject
@@ -662,6 +663,37 @@ class TeamcityClassicClientTest {
             client.deleteProject(project.id)
         }
 
+    }
+
+    @ParameterizedTest
+    @MethodSource("teamcityContexts")
+    fun testUpdateInvestigationComment(config: TeamcityTestConfiguration) {
+        val client = createClient(config)
+        val project = createProject(client, "TestUpdateInvestigationComment")
+        val buildType = createBuildType(client, "TestUpdateInvestigationComment", project.id)
+        try {
+            addInvestigation(client, buildType.id, "TAKEN", "admin", "admin", 1, "whenFixed")
+            val comment = "Updated investigation comment"
+            client.addInvestigation(
+                TeamcityAddInvestigation(
+                    state = "TAKEN",
+                    assignee = TeamcityAssignee(username = "admin", name = "admin", id = 1),
+                    assignment = TeamcityAssignment(text = comment),
+                    scope = TeamcityScope(
+                        buildTypes = TeamcityAddInvestigationBuildTypes(
+                            listOf(TeamcityAddInvestigationBuildType(id = buildType.id))
+                        )
+                    ),
+                    target = TeamcityTarget(anyProblem = true),
+                    resolution = TeamcityResolution(type = "whenFixed")
+                )
+            )
+            val investigations = client.getInvestigationWithInvestigationLocator(buildType.id)
+            assertEquals(1, investigations.investigation.size)
+            assertEquals(comment, investigations.investigation[0].assignment?.text)
+        } finally {
+            client.deleteProject(project.id)
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
 ## Summary
  - Add optional `assignment` field (`TeamcityAssignment`) to `TeamcityAddInvestigation` DTO, enabling investigation comment text to be set when creating or updating investigations via POST
  - Add optional `id` field to `TeamcityInvestigation` DTO for identifying investigations from GET responses
  - Add `testUpdateInvestigationComment` integration test verifying that re-POSTing an investigation with an `assignment` updates the comment text

