### PR TITLE
Add request and limit for FT on okd

### DIFF
--- a/bitbucket-test-client/build.gradle.kts
+++ b/bitbucket-test-client/build.gradle.kts
@@ -48,14 +48,22 @@ ocTemplate {
         service("bitbucket-db") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/bitbucket-db.yaml"))
             parameters.set(commonOkdParameters + mapOf(
-                "POSTGRES_IMAGE_TAG" to properties["postgres.image-tag"] as String
+                "POSTGRES_IMAGE_TAG" to properties["postgres.image-tag"] as String,
+                "CPU_REQUEST" to "10m",
+                "CPU_LIMIT" to "50m",
+                "MEMORY_REQUEST" to "128Mi",
+                "MEMORY_LIMIT" to "200Mi"
             ))
         }
         service("bitbucket") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/bitbucket.yaml"))
             parameters.set(commonOkdParameters + mapOf(
                 "BITBUCKET_LICENSE" to Base64.getEncoder().encodeToString("bitbucketLicense".getExt().toByteArray()),
-                "BITBUCKET_IMAGE_TAG" to properties["bitbucket.image-tag"] as String
+                "BITBUCKET_IMAGE_TAG" to properties["bitbucket.image-tag"] as String,
+                "CPU_REQUEST" to "150m",
+                "CPU_LIMIT" to "2000m",
+                "MEMORY_REQUEST" to "3Gi",
+                "MEMORY_LIMIT" to "4Gi"
             ))
             dependsOn.set(listOf("bitbucket-db"))
         }

--- a/gitea-test-client/build.gradle.kts
+++ b/gitea-test-client/build.gradle.kts
@@ -46,7 +46,11 @@ ocTemplate {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/gitea.yaml"))
             parameters.set(commonOkdParameters + mapOf(
                 "GITEA_IMAGE_TAG" to properties["gitea.image-tag"] as String,
-                "GITEA_ID" to "1"
+                "GITEA_ID" to "1",
+                "CPU_REQUEST" to "5m",
+                "CPU_LIMIT" to "50m",
+                "MEMORY_REQUEST" to "100Mi",
+                "MEMORY_LIMIT" to "150Mi"
             ))
         }
 
@@ -54,7 +58,11 @@ ocTemplate {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/gitea.yaml"))
             parameters.set(commonOkdParameters + mapOf(
                 "GITEA_IMAGE_TAG" to properties["gitea.image-tag"] as String,
-                "GITEA_ID" to "2"
+                "GITEA_ID" to "2",
+                "CPU_REQUEST" to "5m",
+                "CPU_LIMIT" to "50m",
+                "MEMORY_REQUEST" to "100Mi",
+                "MEMORY_LIMIT" to "150Mi"
             ))
         }
     }

--- a/gitea-test-client/build.gradle.kts
+++ b/gitea-test-client/build.gradle.kts
@@ -47,8 +47,8 @@ ocTemplate {
             parameters.set(commonOkdParameters + mapOf(
                 "GITEA_IMAGE_TAG" to properties["gitea.image-tag"] as String,
                 "GITEA_ID" to "1",
-                "CPU_REQUEST" to "5m",
-                "CPU_LIMIT" to "50m",
+                "CPU_REQUEST" to "50m",
+                "CPU_LIMIT" to "500m",
                 "MEMORY_REQUEST" to "256Mi",
                 "MEMORY_LIMIT" to "512Mi"
             ))
@@ -59,8 +59,8 @@ ocTemplate {
             parameters.set(commonOkdParameters + mapOf(
                 "GITEA_IMAGE_TAG" to properties["gitea.image-tag"] as String,
                 "GITEA_ID" to "2",
-                "CPU_REQUEST" to "5m",
-                "CPU_LIMIT" to "50m",
+                "CPU_REQUEST" to "50m",
+                "CPU_LIMIT" to "500m",
                 "MEMORY_REQUEST" to "256Mi",
                 "MEMORY_LIMIT" to "512Mi"
             ))

--- a/gitea-test-client/build.gradle.kts
+++ b/gitea-test-client/build.gradle.kts
@@ -49,8 +49,8 @@ ocTemplate {
                 "GITEA_ID" to "1",
                 "CPU_REQUEST" to "5m",
                 "CPU_LIMIT" to "50m",
-                "MEMORY_REQUEST" to "100Mi",
-                "MEMORY_LIMIT" to "150Mi"
+                "MEMORY_REQUEST" to "256Mi",
+                "MEMORY_LIMIT" to "512Mi"
             ))
         }
 
@@ -61,8 +61,8 @@ ocTemplate {
                 "GITEA_ID" to "2",
                 "CPU_REQUEST" to "5m",
                 "CPU_LIMIT" to "50m",
-                "MEMORY_REQUEST" to "100Mi",
-                "MEMORY_LIMIT" to "150Mi"
+                "MEMORY_REQUEST" to "256Mi",
+                "MEMORY_LIMIT" to "512Mi"
             ))
         }
     }

--- a/okd/bitbucket-db.yaml
+++ b/okd/bitbucket-db.yaml
@@ -26,6 +26,13 @@ objects:
       containers:
         - name: bitbucket-db
           image: ${DOCKER_REGISTRY}/postgres:${POSTGRES_IMAGE_TAG}
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
           env:
             - name: POSTGRES_DB
               value: bitbucket
@@ -76,4 +83,16 @@ parameters:
     required: true
   - description: Tag of postgres image
     name: POSTGRES_IMAGE_TAG
+    required: true
+  - description: CPU request
+    name: CPU_REQUEST
+    required: true
+  - description: CPU limit
+    name: CPU_LIMIT
+    required: true
+  - description: Memory request
+    name: MEMORY_REQUEST
+    required: true
+  - description: Memory limit
+    name: MEMORY_LIMIT
     required: true

--- a/okd/bitbucket.yaml
+++ b/okd/bitbucket.yaml
@@ -33,6 +33,13 @@ objects:
       containers:
         - name: bitbucket
           image: ${DOCKER_REGISTRY}/atlassian/bitbucket:${BITBUCKET_IMAGE_TAG}
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
           env:
             - name: SETUP_LICENSE
               valueFrom:
@@ -120,4 +127,16 @@ parameters:
     required: true
   - description: Tag of atlassian/bitbucket-server image
     name: BITBUCKET_IMAGE_TAG
+    required: true
+  - description: CPU request
+    name: CPU_REQUEST
+    required: true
+  - description: CPU limit
+    name: CPU_LIMIT
+    required: true
+  - description: Memory request
+    name: MEMORY_REQUEST
+    required: true
+  - description: Memory limit
+    name: MEMORY_LIMIT
     required: true

--- a/okd/gitea.yaml
+++ b/okd/gitea.yaml
@@ -35,6 +35,13 @@ objects:
       containers:
         - name: gitea-${GITEA_ID}
           image: ${DOCKER_REGISTRY}/gitea/gitea:${GITEA_IMAGE_TAG}
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
           env:
             - name: GITEA__server__OFFLINE_MODE
               value: "false"
@@ -111,4 +118,16 @@ parameters:
     required: true
   - description: ID of gitea instance
     name: GITEA_ID
+    required: true
+  - description: CPU request
+    name: CPU_REQUEST
+    required: true
+  - description: CPU limit
+    name: CPU_LIMIT
+    required: true
+  - description: Memory request
+    name: MEMORY_REQUEST
+    required: true
+  - description: Memory limit
+    name: MEMORY_LIMIT
     required: true

--- a/okd/teamcity.yaml
+++ b/okd/teamcity.yaml
@@ -22,6 +22,13 @@ objects:
       containers:
         - name: teamcity${TEAMCITY_ID}
           image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_IMAGE_TAG}
+          resources:
+            requests:
+              cpu: ${CPU_REQUEST}
+              memory: ${MEMORY_REQUEST}
+            limits:
+              cpu: ${CPU_LIMIT}
+              memory: ${MEMORY_LIMIT}
           ports:
             - containerPort: 8111
               protocol: TCP
@@ -73,4 +80,16 @@ parameters:
     required: true
   - description: TeamCity instance identifier
     name: TEAMCITY_ID
+    required: true
+  - description: CPU request
+    name: CPU_REQUEST
+    required: true
+  - description: CPU limit
+    name: CPU_LIMIT
+    required: true
+  - description: Memory request
+    name: MEMORY_REQUEST
+    required: true
+  - description: Memory limit
+    name: MEMORY_LIMIT
     required: true

--- a/teamcity-client/build.gradle.kts
+++ b/teamcity-client/build.gradle.kts
@@ -95,14 +95,22 @@ ocTemplate {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity.yaml"))
             parameters.set(commonOkdParameters + mapOf(
                 "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
-                "TEAMCITY_ID" to "22"
+                "TEAMCITY_ID" to "22",
+                "CPU_REQUEST" to "500m",
+                "CPU_LIMIT" to "2000m",
+                "MEMORY_REQUEST" to "1.5Gi",
+                "MEMORY_LIMIT" to "2Gi"
             ))
         }
         service("teamcity25") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity.yaml"))
             parameters.set(commonOkdParameters + mapOf(
                 "TEAMCITY_IMAGE_TAG" to project.properties["teamcity-2025.image-tag"] as String,
-                "TEAMCITY_ID" to "25"
+                "TEAMCITY_ID" to "25",
+                "CPU_REQUEST" to "500m",
+                "CPU_LIMIT" to "2000m",
+                "MEMORY_REQUEST" to "1.2Gi",
+                "MEMORY_LIMIT" to "1.5Gi"
             ))
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented Kubernetes resource management by configuring explicit CPU and memory request and limit parameters across multiple service deployments. Bitbucket (database and application), Gitea, and TeamCity instances now have proper resource constraints defined to optimize resource utilization, prevent resource contention, and improve overall system stability and reliability across all deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->