### PR TITLE
Change docker registry for teamcity data uploader

### DIFF
--- a/okd/teamcity-uploader.yaml
+++ b/okd/teamcity-uploader.yaml
@@ -23,7 +23,7 @@ objects:
           emptyDir: { }
       containers:
         - name: uploader
-          image: public.ecr.aws/docker/library/busybox:1.37
+          image: ${DOCKER_REGISTRY}/busybox:1.37
           command: ["sh","-c"]
           args:
             - |
@@ -58,6 +58,9 @@ parameters:
     required: true
   - description: Active deadline seconds
     name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
     required: true
   - description: Service account name with SCC - anyuid
     name: SERVICE_ACCOUNT_ANYUID

--- a/teamcity-client/build.gradle.kts
+++ b/teamcity-client/build.gradle.kts
@@ -106,7 +106,7 @@ ocTemplate {
                 "CPU_REQUEST" to "500m",
                 "CPU_LIMIT" to "2000m",
                 "MEMORY_REQUEST" to "1.2Gi",
-                "MEMORY_LIMIT" to "1.5Gi"
+                "MEMORY_LIMIT" to "2Gi"
             ))
         }
     }

--- a/teamcity-client/build.gradle.kts
+++ b/teamcity-client/build.gradle.kts
@@ -74,17 +74,13 @@ ocTemplate {
     group("teamcitySeedUploaders").apply {
         service("teamcity22-uploader") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-uploader.yaml"))
-            parameters.set(mapOf(
-                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
-                "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+            parameters.set(commonOkdParameters + mapOf(
                 "TEAMCITY_ID" to "22"
             ))
         }
         service("teamcity25-uploader") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-uploader.yaml"))
-            parameters.set(mapOf(
-                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
-                "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+            parameters.set(commonOkdParameters + mapOf(
                 "TEAMCITY_ID" to "25"
             ))
         }


### PR DESCRIPTION
Also increased teamcity25 memory limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker registry location is now configurable via a required DOCKER_REGISTRY parameter, enabling use of custom/private registries.

* **Chores**
  * Refactored template/configuration to reduce duplication and centralize common parameters.
  * Increased server memory limit from 1.5Gi to 2Gi for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->