### PR TITLE
For v2026, edit the MetaRunner if it already exists instead of deleting it

### DIFF
--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClient.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClient.kt
@@ -189,6 +189,9 @@ class TeamcityClassicClient(
     override fun deleteRecipeV2026(recipeId: String, projectId: String) =
         client.deleteRecipeV2026(recipeId, projectId)
 
+    override fun updateRecipeV2026(recipeId: String, projectId: String, content: String) =
+        client.updateRecipeV2026(recipeId, projectId, content)
+
     override fun queueBuild(build: TeamcityCreateQueuedBuild): TeamcityQueuedBuild = client.queueBuild(build)
 
     override fun getProjectsWithLocatorAndFields(locator: ProjectLocator, fields: String): TeamcityProjects =

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClient.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClient.kt
@@ -2,6 +2,7 @@ package org.octopusden.octopus.infrastructure.teamcity.client
 
 import com.fasterxml.jackson.annotation.JsonValue
 import feign.Body
+import feign.FeignException
 import feign.Headers
 import feign.Param
 import feign.RequestLine
@@ -583,8 +584,15 @@ fun TeamcityClient.uploadMetarunner(projectId: String, fileName: String, fileCon
         else -> {
             // TC 2026's POST /app/recipes/private is create-only; in-use recipes also cannot be
             // deleted. Probe existence and PUT to update, otherwise POST to create.
+            // Only treat 404 as "not found" — let auth/server errors propagate so we don't mask
+            // them by falling through to the create-only path.
             val recipeId = fileName.removeSuffix(".xml")
-            val exists = runCatching { getRecipeOverviewV2026(recipeId, projectId) }.isSuccess
+            val exists = try {
+                getRecipeOverviewV2026(recipeId, projectId)
+                true
+            } catch (e: FeignException.NotFound) {
+                false
+            }
             if (exists) {
                 updateRecipeV2026(recipeId, projectId, String(fileContent))
             } else {

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClient.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClient.kt
@@ -415,6 +415,14 @@ interface TeamcityClient {
         @Param(value = "projectId") projectId: String
     )
 
+    @RequestLine("PUT /app/recipes/private?recipeId={recipeId}&projectId={projectId}")
+    @Headers("Content-Type: application/json", "Accept: application/json")
+    fun updateRecipeV2026(
+        @Param(value = "recipeId") recipeId: String,
+        @Param(value = "projectId") projectId: String,
+        content: String
+    )
+
     @RequestLine("POST $REST/buildQueue")
     @Headers("Content-Type: application/json", "Accept: application/json")
     fun queueBuild(build: TeamcityCreateQueuedBuild): TeamcityQueuedBuild
@@ -573,11 +581,15 @@ fun TeamcityClient.uploadMetarunner(projectId: String, fileName: String, fileCon
         majorVersion < 2026 ->
             uploadRecipe(fileName, FormData("text/xml", fileName, fileContent), "uploadRecipe", projectId)
         else -> {
-            // TC 2026's POST /app/recipes/private is create-only and rejects duplicate IDs.
-            // To preserve upsert semantics of this function, delete first (ignore if absent),
-            // then create.
-            runCatching { deleteRecipeV2026(fileName.removeSuffix(".xml"), projectId) }
-            uploadRecipeV2026(projectId, fileName, FormData("text/xml", fileName, fileContent))
+            // TC 2026's POST /app/recipes/private is create-only; in-use recipes also cannot be
+            // deleted. Probe existence and PUT to update, otherwise POST to create.
+            val recipeId = fileName.removeSuffix(".xml")
+            val exists = runCatching { getRecipeOverviewV2026(recipeId, projectId) }.isSuccess
+            if (exists) {
+                updateRecipeV2026(recipeId, projectId, String(fileContent))
+            } else {
+                uploadRecipeV2026(projectId, fileName, FormData("text/xml", fileName, fileContent))
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating recipes in TeamCity 2026+ via a dedicated recipe update endpoint.

* **Improvements**
  * Recipe upload now probes for existing recipes and performs an upsert (update if present, create if missing), avoiding unnecessary delete-and-recreate cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->