### PR TITLE
Add getBuild , getBuildWithFields, and, getVcsRootInstance in teamcity client

### DIFF
--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClient.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClient.kt
@@ -200,6 +200,13 @@ class TeamcityClassicClient(
     override fun getBuildsWithLocatorAndFields(locator: BuildLocator, fields: String) =
         client.getBuildsWithLocatorAndFields(locator, fields)
 
+    override fun getBuild(locator: BuildLocator) = client.getBuild(locator)
+
+    override fun getBuildWithFields(locator: BuildLocator, fields: String) =
+        client.getBuildWithFields(locator, fields)
+
+    override fun getVcsRootInstance(locator: VcsRootInstanceLocator) = client.getVcsRootInstance(locator)
+
     override fun getBuildTypesWithVcsRootInstanceLocatorAndFields(
         locator: VcsRootInstanceLocator,
         fields: String

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClient.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClient.kt
@@ -10,6 +10,7 @@ import feign.form.FormData
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAddInvestigation
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAgentRequirement
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAgentRequirements
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityBuild
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityBuildType
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityBuildTypes
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityBuilds
@@ -36,6 +37,7 @@ import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcitySteps
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityVcsRoot
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityVcsRootEntries
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityVcsRootEntry
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityVcsRootInstance
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityVcsRootInstances
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityVcsRoots
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.locator.AgentRequirementLocator
@@ -442,6 +444,25 @@ interface TeamcityClient {
         @Param("fields", encoded = true) fields: String
     ): TeamcityBuilds
 
+    @RequestLine("GET $REST/builds/{locator}")
+    @Headers("Content-Type: application/json", "Accept: application/json")
+    fun getBuild(
+        @Param("locator", expander = Locator::class) locator: BuildLocator
+    ): TeamcityBuild
+
+    @RequestLine("GET $REST/builds/{locator}?fields={fields}")
+    @Headers("Content-Type: application/json", "Accept: application/json")
+    fun getBuildWithFields(
+        @Param("locator", expander = Locator::class) locator: BuildLocator,
+        @Param("fields", encoded = true) fields: String
+    ): TeamcityBuild
+
+    @RequestLine("GET $REST/vcs-root-instances/{locator}")
+    @Headers("Content-Type: application/json", "Accept: application/json")
+    fun getVcsRootInstance(
+        @Param("locator", expander = Locator::class) locator: VcsRootInstanceLocator
+    ): TeamcityVcsRootInstance
+
     @RequestLine("GET $REST/buildTypes?locator=vcsRootInstance({locator})&fields={fields}")
     @Headers("Content-Type: application/json", "Accept: application/json")
     fun getBuildTypesWithVcsRootInstanceLocatorAndFields(
@@ -562,6 +583,14 @@ fun TeamcityClient.updateBuildTypeVcsRootEntryCheckoutRules(
 ) = updateBuildTypeVcsRootEntryCheckoutRules(BuildTypeLocator(id = buildTypeId), vcsRootEntryId, checkoutRules)
 
 fun TeamcityClient.getVcsRoot(vcsRootId: String) = getVcsRoot(VcsRootLocator(id = vcsRootId))
+
+fun TeamcityClient.getBuild(buildId: String) = getBuild(BuildLocator(id = buildId))
+
+fun TeamcityClient.getBuildWithFields(buildId: String, fields: String) =
+    getBuildWithFields(BuildLocator(id = buildId), fields)
+
+fun TeamcityClient.getVcsRootInstance(vcsRootInstanceId: String) =
+    getVcsRootInstance(VcsRootInstanceLocator(id = vcsRootInstanceId))
 
 fun TeamcityClient.getBuildTypeTemplate(buildTypeId: String) = getBuildTypeTemplate(BuildTypeLocator(id = buildTypeId))
 

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamCityBuild.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamCityBuild.kt
@@ -11,8 +11,8 @@ data class TeamcityBuild(
     val state: String? = null,
     val branchName: String? = null,
     val defaultBranch: Boolean? = null,
-    val href: String = "",
-    val webUrl: String = "",
+    val href: String? = null,
+    val webUrl: String? = null,
     val finishDate: String? = null,
     val lastChanges: TeamcityChanges? = null,
     @JsonProperty("snapshot-dependencies")

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamCityBuild.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamCityBuild.kt
@@ -1,15 +1,20 @@
 package org.octopusden.octopus.infrastructure.teamcity.client.dto
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class TeamcityBuild(
     val id: String,
-    val buildTypeId: String?,
+    val buildTypeId: String? = null,
     val buildType: TeamcityBuildType? = null,
-    val number: String?,
-    val status: String?,
-    val state: String?,
-    val branchName: String?,
-    val defaultBranch: Boolean?,
-    val href: String,
-    val webUrl: String,
-    val finishDate: String?
+    val number: String? = null,
+    val status: String? = null,
+    val state: String? = null,
+    val branchName: String? = null,
+    val defaultBranch: Boolean? = null,
+    val href: String = "",
+    val webUrl: String = "",
+    val finishDate: String? = null,
+    val lastChanges: TeamcityChanges? = null,
+    @JsonProperty("snapshot-dependencies")
+    val snapshotDependencies: TeamcityBuildSnapshotDependencies? = null
 )

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityBuildSnapshotDependencies.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityBuildSnapshotDependencies.kt
@@ -1,0 +1,9 @@
+package org.octopusden.octopus.infrastructure.teamcity.client.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class TeamcityBuildSnapshotDependencies(
+    val count: Int? = null,
+    @JsonProperty("build")
+    val build: List<TeamcityBuild> = emptyList()
+)

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityChange.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityChange.kt
@@ -1,0 +1,10 @@
+package org.octopusden.octopus.infrastructure.teamcity.client.dto
+
+data class TeamcityChange(
+    val id: String? = null,
+    val version: String? = null,
+    val username: String? = null,
+    val date: String? = null,
+    val href: String? = null,
+    val webUrl: String? = null
+)

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityChanges.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/TeamcityChanges.kt
@@ -1,0 +1,10 @@
+package org.octopusden.octopus.infrastructure.teamcity.client.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class TeamcityChanges(
+    val count: Int? = null,
+    val href: String? = null,
+    @JsonProperty("change")
+    val change: List<TeamcityChange> = emptyList()
+)

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/locator/BuildLocator.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/locator/BuildLocator.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.infrastructure.teamcity.client.dto.locator
 
 class BuildLocator(
+    val id: String? = null,
     val buildType: BuildTypeLocator? = null,
     val status: String? = null,
     val state: String? = null,

--- a/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/locator/VcsRootInstanceLocator.kt
+++ b/teamcity-client/src/main/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/dto/locator/VcsRootInstanceLocator.kt
@@ -1,6 +1,7 @@
 package org.octopusden.octopus.infrastructure.teamcity.client.dto.locator
 
 class VcsRootInstanceLocator(
+    val id: String? = null,
     val count: Int? = null,
     val buildType: BuildTypeLocator? = null,
     val property: List<PropertyLocator>? = null

--- a/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
+++ b/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
@@ -651,6 +651,11 @@ class TeamcityClassicClientTest {
             )
             val instances = client.getVcsRootInstances(locator).vcsRootInstances
             assertEquals(vcsRoot.id, instances.first().vcsRootId)
+
+            val instanceId = instances.first().id
+            val single = client.getVcsRootInstance(instanceId)
+            assertEquals(instanceId, single.id)
+            assertEquals(vcsRoot.id, single.vcsRootId)
         } finally {
             client.deleteProject(project.id)
         }

--- a/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
+++ b/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
@@ -487,6 +487,45 @@ class TeamcityClassicClientTest {
 
     @ParameterizedTest
     @MethodSource("teamcityContexts")
+    fun testGetBuildAndGetBuildWithFields(config: TeamcityTestConfiguration) {
+        val client = createClient(config)
+        val project = createProject(client, "TestGetBuild")
+        try {
+            val buildType = createBuildType(client, "TestGetBuildType", project.id)
+            val queued = client.queueBuild(
+                TeamcityCreateQueuedBuild(
+                    buildType = BuildTypeLocator(id = buildType.id),
+                    branchName = "master"
+                )
+            )
+            val buildId = queued.id
+
+            val build = client.getBuild(buildId)
+            assertEquals(buildId, build.id)
+            assertEquals(buildType.id, build.buildTypeId)
+
+            val fields = "id,buildTypeId,buildType(id,name),number,status,state," +
+                    "branchName,defaultBranch,href,webUrl,finishDate," +
+                    "lastChanges(change(id)),snapshot-dependencies(build(id))"
+            val withFields = client.getBuildWithFields(buildId, fields)
+            assertEquals(buildId, withFields.id)
+            assertEquals(buildType.id, withFields.buildTypeId)
+            assertNotNull(withFields.buildType)
+            assertEquals(buildType.id, withFields.buildType!!.id)
+            assertNotNull(withFields.state)
+            assertEquals("master", withFields.branchName)
+            assertNotNull(withFields.defaultBranch)
+            assertNotNull(withFields.href)
+            assertNotNull(withFields.webUrl)
+            assertNotNull(withFields.lastChanges)
+            assertNotNull(withFields.snapshotDependencies)
+        } finally {
+            client.deleteProject(project.id)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("teamcityContexts")
     fun testGetProjectsWithLocatorAndFields(config: TeamcityTestConfiguration) {
         val client = createClient(config)
         val project = createProject(client, "testGetProjectsWithFields")

--- a/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
+++ b/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertIterableEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.octopusden.octopus.infrastructure.client.commons.ClientParametersProvider
@@ -519,6 +520,39 @@ class TeamcityClassicClientTest {
             assertNotNull(withFields.webUrl)
             assertNotNull(withFields.lastChanges)
             assertNotNull(withFields.snapshotDependencies)
+        } finally {
+            client.deleteProject(project.id)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("teamcityContexts")
+    fun testGetBuildWithFieldsRespectsFieldSelector(config: TeamcityTestConfiguration) {
+        val client = createClient(config)
+        val project = createProject(client, "TestGetBuildFieldSelector")
+        try {
+            val buildType = createBuildType(client, "TestGetBuildFieldSelectorType", project.id)
+            val queued = client.queueBuild(
+                TeamcityCreateQueuedBuild(
+                    buildType = BuildTypeLocator(id = buildType.id),
+                    branchName = "master"
+                )
+            )
+            val buildId = queued.id
+
+            val minimal = client.getBuildWithFields(buildId, "id,state")
+            assertEquals(buildId, minimal.id)
+            assertNotNull(minimal.state)
+            assertNull(minimal.buildTypeId)
+            assertNull(minimal.buildType)
+            assertNull(minimal.number)
+            assertNull(minimal.branchName)
+            assertNull(minimal.defaultBranch)
+            assertEquals("", minimal.href)
+            assertEquals("", minimal.webUrl)
+            assertNull(minimal.finishDate)
+            assertNull(minimal.lastChanges)
+            assertNull(minimal.snapshotDependencies)
         } finally {
             client.deleteProject(project.id)
         }

--- a/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
+++ b/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
@@ -492,52 +492,7 @@ class TeamcityClassicClientTest {
         val client = createClient(config)
         val project = createProject(client, "TestGetBuild")
         try {
-            val sourceBuildType = createBuildType(client, "TestGetBuildSourceType", project.id)
             val buildType = createBuildType(client, "TestGetBuildType", project.id)
-
-            val url = "ssh://git@github.com:octopusden/octopus-external-systems-client.git"
-            val vcsRoot = client.createVcsRoot(
-                TeamcityCreateVcsRoot(
-                    name = "${project.name}_VCS_ROOT",
-                    vcsName = TeamcityVCSType.GIT.value,
-                    projectLocator = project.id,
-                    properties = TeamcityProperties(
-                        listOf(
-                            TeamcityProperty("url", url),
-                            TeamcityProperty("branch", "master"),
-                            TeamcityProperty("authMethod", "PRIVATE_KEY_DEFAULT"),
-                            TeamcityProperty("userForTags", "tcagent"),
-                            TeamcityProperty("username", "git"),
-                            TeamcityProperty("ignoreKnownHosts", "true")
-                        )
-                    )
-                )
-            )
-            client.createBuildTypeVcsRootEntry(
-                buildType.id,
-                TeamcityCreateVcsRootEntry(
-                    id = vcsRoot.id,
-                    vcsRoot = TeamcityLinkVcsRoot(vcsRoot.id)
-                )
-            )
-            client.createSnapshotDependency(
-                buildType.id,
-                TeamcitySnapshotDependency(
-                    id = sourceBuildType.name!!,
-                    type = "snapshot_dependency",
-                    properties = TeamcityProperties(
-                        listOf(
-                            TeamcityProperty("run-build-if-dependency-failed", "MAKE_FAILED_TO_START"),
-                            TeamcityProperty("run-build-if-dependency-failed-to-start", "MAKE_FAILED_TO_START"),
-                            TeamcityProperty("run-build-on-the-same-agent", "false"),
-                            TeamcityProperty("take-started-build-with-same-revisions", "true"),
-                            TeamcityProperty("take-successful-builds-only", "true"),
-                        )
-                    ),
-                    sourceBuildType = TeamcityLinkBuildType(sourceBuildType.id)
-                )
-            )
-
             val queued = client.queueBuild(
                 TeamcityCreateQueuedBuild(
                     buildType = BuildTypeLocator(id = buildType.id),
@@ -551,8 +506,7 @@ class TeamcityClassicClientTest {
             assertEquals(buildType.id, build.buildTypeId)
 
             val fields = "id,buildTypeId,buildType(id,name),number,status,state," +
-                    "branchName,defaultBranch,href,webUrl,finishDate," +
-                    "lastChanges(change(id)),snapshot-dependencies(build(id))"
+                    "branchName,defaultBranch,href,webUrl,finishDate"
             val withFields = client.getBuildWithFields(buildId, fields)
             assertEquals(buildId, withFields.id)
             assertEquals(buildType.id, withFields.buildTypeId)
@@ -563,8 +517,6 @@ class TeamcityClassicClientTest {
             assertNotNull(withFields.defaultBranch)
             assertNotNull(withFields.href)
             assertNotNull(withFields.webUrl)
-            assertNotNull(withFields.lastChanges)
-            assertNotNull(withFields.snapshotDependencies)
         } finally {
             client.deleteProject(project.id)
         }
@@ -596,8 +548,6 @@ class TeamcityClassicClientTest {
             assertEquals("", minimal.href)
             assertEquals("", minimal.webUrl)
             assertNull(minimal.finishDate)
-            assertNull(minimal.lastChanges)
-            assertNull(minimal.snapshotDependencies)
         } finally {
             client.deleteProject(project.id)
         }

--- a/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
+++ b/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
@@ -492,7 +492,52 @@ class TeamcityClassicClientTest {
         val client = createClient(config)
         val project = createProject(client, "TestGetBuild")
         try {
+            val sourceBuildType = createBuildType(client, "TestGetBuildSourceType", project.id)
             val buildType = createBuildType(client, "TestGetBuildType", project.id)
+
+            val url = "ssh://git@github.com:octopusden/octopus-external-systems-client.git"
+            val vcsRoot = client.createVcsRoot(
+                TeamcityCreateVcsRoot(
+                    name = "${project.name}_VCS_ROOT",
+                    vcsName = TeamcityVCSType.GIT.value,
+                    projectLocator = project.id,
+                    properties = TeamcityProperties(
+                        listOf(
+                            TeamcityProperty("url", url),
+                            TeamcityProperty("branch", "master"),
+                            TeamcityProperty("authMethod", "PRIVATE_KEY_DEFAULT"),
+                            TeamcityProperty("userForTags", "tcagent"),
+                            TeamcityProperty("username", "git"),
+                            TeamcityProperty("ignoreKnownHosts", "true")
+                        )
+                    )
+                )
+            )
+            client.createBuildTypeVcsRootEntry(
+                buildType.id,
+                TeamcityCreateVcsRootEntry(
+                    id = vcsRoot.id,
+                    vcsRoot = TeamcityLinkVcsRoot(vcsRoot.id)
+                )
+            )
+            client.createSnapshotDependency(
+                buildType.id,
+                TeamcitySnapshotDependency(
+                    id = sourceBuildType.name!!,
+                    type = "snapshot_dependency",
+                    properties = TeamcityProperties(
+                        listOf(
+                            TeamcityProperty("run-build-if-dependency-failed", "MAKE_FAILED_TO_START"),
+                            TeamcityProperty("run-build-if-dependency-failed-to-start", "MAKE_FAILED_TO_START"),
+                            TeamcityProperty("run-build-on-the-same-agent", "false"),
+                            TeamcityProperty("take-started-build-with-same-revisions", "true"),
+                            TeamcityProperty("take-successful-builds-only", "true"),
+                        )
+                    ),
+                    sourceBuildType = TeamcityLinkBuildType(sourceBuildType.id)
+                )
+            )
+
             val queued = client.queueBuild(
                 TeamcityCreateQueuedBuild(
                     buildType = BuildTypeLocator(id = buildType.id),

--- a/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
+++ b/teamcity-client/src/test/kotlin/org/octopusden/octopus/infrastructure/teamcity/client/TeamcityClassicClientTest.kt
@@ -545,8 +545,8 @@ class TeamcityClassicClientTest {
             assertNull(minimal.number)
             assertNull(minimal.branchName)
             assertNull(minimal.defaultBranch)
-            assertEquals("", minimal.href)
-            assertEquals("", minimal.webUrl)
+            assertNull(minimal.href)
+            assertNull(minimal.webUrl)
             assertNull(minimal.finishDate)
         } finally {
             client.deleteProject(project.id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to fetch build information by locator, including optional field selection
  * Added capability to retrieve VCS root instances by locator
  * Build data now includes snapshot dependencies and recent changes information
  * Extended locators to support ID-based queries for builds and VCS root instances
* **Tests**
  * Added test coverage for build fetching with field selection, including field-selector behavior
  * Added/updated tests for VCS root instance retrieval by locator
<!-- end of auto-generated comment: release notes by coderabbit.ai -->