### PR TITLE
ci: move octopus-base to v2.7.0 and replace a tautological guard with the shared policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/octopus-external-systems-clients/jira-client/_VER_/jira-client-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -25,6 +25,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
     with:
       java-version: '21'
       # Coverage is disabled for this repo (octopusQuality { coverage { enabled = false } }).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
     with:
       java-version: '21'
       enable-codeql: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,48 @@ plugins {
 }
 
 octopusQuality {
+    // Regression guard on what reaches Maven Central, from octopus-base v2.7.0. This repository
+    // previously hand-rolled a task of the SAME name, deleted in this commit — two tasks with one
+    // name fail configuration, so the bump and the deletion cannot be separated.
+    //
+    // The declared set is deliberately INDEPENDENT of `centralPublishedProjects` below, which
+    // gates publication creation. The old local guard compared `centralPublishedProjects` against
+    // the projects that publish — but that same list decides which projects publish, so both sides
+    // moved together and an edit to it could never be reported as drift. Only an addition arriving
+    // by some other route was catchable. Declaring the expected coordinates separately is what
+    // makes editing the list a detectable change.
+    publication {
+        // Spelled out rather than derived from the module list: deriving it would recreate the
+        // tautology described above. Only the groupId, a constant, is factored out.
+        val group = "org.octopusden.octopus.octopus-external-systems-clients"
+        enforceCentralPublications.set(true)
+        centralPublications.set(
+            setOf(
+                ":artifactory-client|maven|${group}:artifactory-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":bitbucket-client|maven|${group}:bitbucket-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":bitbucket-test-client|maven|${group}:bitbucket-test-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":client-commons|maven|${group}:client-commons|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":confluence-client|maven|${group}:confluence-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":gitea-client|maven|${group}:gitea-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":gitea-test-client|maven|${group}:gitea-test-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":jira-client|maven|${group}:jira-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":sonarqube-client|maven|${group}:sonarqube-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":teamcity-client|maven|${group}:teamcity-client|" +
+                    "[jar, jar:javadoc, jar:sources]",
+                ":test-client-commons|maven|${group}:test-client-commons|" +
+                    "[jar, jar:javadoc, jar:sources]",
+            ),
+        )
+    }
     kotlin {
         failOnViolation.set(true)
     }
@@ -92,7 +134,7 @@ subprojects {
     val gitUrl = "https://github.com/octopusden/octopus-external-systems-client.git"
 
     // `maven-publish` stays applied above even for a project that is not allowlisted, so the
-    // `publish` lifecycle task still exists as a no-op and the policy check below can read
+    // `publish` lifecycle task still exists as a no-op and the publication policy can read
     // `publishing` on every project. Only the publication itself is conditional.
     if (project.path in centralPublishedProjects) {
     publishing {
@@ -183,64 +225,5 @@ subprojects {
 
     dependencies {
         implementation("org.jetbrains.kotlin:kotlin-stdlib")
-    }
-}
-
-// Regression guard: fails if the set of projects publishing to Maven Central drifts from the
-// allowlist above. Needed here specifically because `maven-publish` is applied to every
-// subproject unconditionally, so a new module would otherwise start publishing ~50 files to
-// Central without anyone deciding to.
-//
-// allprojects, not subprojects: the root is a publishable project like any other, and a
-// publication added there would otherwise be invisible.
-fun centralPublicationPolicyProblems(): List<String> {
-    val publishingProjects = allprojects.filter { candidate ->
-        candidate.plugins.hasPlugin("maven-publish") &&
-            candidate.extensions
-                .getByType(PublishingExtension::class.java)
-                .publications
-                .isNotEmpty()
-    }
-    val actual = publishingProjects.map { it.path }.toSet()
-    return if (actual != centralPublishedProjects) {
-        listOf(
-            "Maven Central publication set drifted.\n" +
-                "  allowlisted: ${centralPublishedProjects.sorted()}\n" +
-                "  publishing:  ${actual.sorted()}\n" +
-                "Update centralPublishedProjects in the root build script only if the change is intentional.",
-        )
-    } else {
-        emptyList()
-    }
-}
-
-// A policy violation must fail its own gate, not every Gradle invocation: throwing at
-// configuration time would break build, test, dependencies and IDE sync as well.
-val verifyCentralPublicationPolicy =
-    tasks.register("verifyCentralPublicationPolicy") {
-        group = "verification"
-        description = "Fails if the set of projects publishing to Maven Central drifts from the allowlist."
-        doLast {
-            val problems = centralPublicationPolicyProblems()
-            if (problems.isNotEmpty()) {
-                throw GradleException(problems.joinToString("\n\n"))
-            }
-            logger.lifecycle(
-                "Maven Central publication set matches the allowlist (${centralPublishedProjects.size} projects).",
-            )
-        }
-    }
-
-// Hook the task TYPE, so a concrete task such as publishMavenPublicationToMavenLocal cannot
-// bypass the guard; the aggregates are matched by name as well because `publish` is per-project
-// and `publishToSonatype` only exists with -Pnexus, so neither can be forced into existence.
-gradle.projectsEvaluated {
-    allprojects {
-        tasks.withType(AbstractPublishToMaven::class.java).configureEach {
-            dependsOn(verifyCentralPublicationPolicy)
-        }
-        tasks
-            .matching { it.name in setOf("publishToSonatype", "publish", "publishToMavenLocal") }
-            .configureEach { dependsOn(verifyCentralPublicationPolicy) }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.version=1.9.22
 junit-jupiter.version=5.9.2
 
 # Octopus quality gates (org.octopusden.octopus-quality convention plugin)
-octopus-quality.version=2.6.2
+octopus-quality.version=2.7.0
 detekt.version=1.23.8
 ktlint-gradle.version=14.0.1
 


### PR DESCRIPTION
## What

Three changes that must land together:

- all six `octopus-base` workflow refs and `octopus-quality.version` in `gradle.properties` move to **v2.7.0**;
- the hand-rolled `verifyCentralPublicationPolicy` (58 lines in `build.gradle.kts`) is **deleted**;
- the expected publication set is declared through `octopusQuality { publication { … } }`, which v2.7.0 provides — and is now **independent** of the list that creates the publications.

## Why the bump and the deletion cannot be split

octopus-base v2.7.0's quality plugin registers a task named exactly `verifyCentralPublicationPolicy`. Two tasks of one name fail configuration, so bumping first and deleting the local copy in a follow-up would break the build in between.

## The third change is a defect fix, not a move

The old guard compared `centralPublishedProjects` against the projects that publish — but that same list decides which projects publish:

```kotlin
if (project.path in centralPublishedProjects) { publishing { … } }
```

Both sides therefore moved together, and an edit to the list could never be reported as drift for a module that actually exists. Two narrower things stayed catchable, and the claim should not be read as "the guard did nothing": a publication created by some route other than that gate (e.g. directly on the root project), and a path typo'd into the allowlist, since `actual` can never contain a project that does not exist. Demonstrated on the parent commit `b39836f`: removing `:test-client-commons` from the list leaves the task **passing**, printing "publication set matches the allowlist (10 projects)" — the count silently dropped from 11 to 10 and nothing complained.

Declaring the expected coordinates as separate data is what makes that edit detectable.

## Where the declared set came from

Not written by hand: declare an empty set, run the task, copy what it prints as `publishing:`. 11 coordinates, each `[jar, jar:javadoc, jar:sources]`. `test-client-test-commons` stays excluded, as of #145.

Only the groupId — a constant — is factored into a local `val`; it is not derived from the project list, so no coupling is reintroduced.

## Verification

Run locally against the real v2.7.0 plugin resolved from Central, which also confirms the freshly published plugin is consumable:

- **GREEN** — `verifyCentralPublicationPolicy` passes with the declared set;
- **RED on the axis that matters** — removing `:test-client-commons` from the *creation* list while leaving `centralPublications` untouched **fails** the task, printing declared (11) vs publishing (10). The same edit passed under the previous guard, which is what makes this more than a refactor;
- restored → GREEN again, so it is not red in both states;
- `./gradlew check --dry-run` schedules the task exactly **once**, so an ordinary PR gate covers it rather than only the release;
- `ktlintCheck`, `ktlintKotlinScriptCheck` and `assemble` pass;
- whole-tree grep for `2.6.2`: zero hits.

## Not verified locally

Tests — they need a docker platform this machine cannot provide (the images involved are amd64-only). CI covers them.

## This PR was repurposed rather than newly opened

It was opened 2026-07-28 to bump v2.4.1 → v2.5.2. `main` has since moved to v2.6.2, so **merging it as it stood would have downgraded the pins**, dropping the publication guard (v2.6.0) and built-commit tagging (v2.6.2), while its title advertised "restores Maven Central releases". Reset onto `main` and reused instead of opening a second PR.

The branch name `chore/octopus-base-2.5.2` is stale for the same reason; renaming it would break this PR's ref, so it is left alone deliberately.
