### PR TITLE
build: make Central publishing opt-in and stop publishing test-client-test-commons (−50 files/release) + octopus-base v2.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/octopus-external-systems-clients/jira-client/_VER_/jira-client-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -25,6 +25,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
     with:
       java-version: '21'
       # Coverage is disabled for this repo (octopusQuality { coverage { enabled = false } }).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
     with:
       java-version: '21'
       enable-codeql: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,27 @@ allprojects {
     }
 }
 
+// Which projects publish to Maven Central. An ALLOWLIST, not a denylist: the block below
+// applies `maven-publish` to every subproject, so without this a newly added module would start
+// publishing 50 files to Central the moment it is created, silently. Adding a coordinate is now
+// an explicit edit here.
+//
+// Paths, not names: a Set of names collapses two modules that share a simple name, and the root
+// project's name is a repository-level string rather than a module name.
+val centralPublishedProjects = setOf(
+    ":artifactory-client",
+    ":bitbucket-client",
+    ":bitbucket-test-client",
+    ":client-commons",
+    ":confluence-client",
+    ":gitea-client",
+    ":gitea-test-client",
+    ":jira-client",
+    ":sonarqube-client",
+    ":teamcity-client",
+    ":test-client-commons",
+)
+
 subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "idea")
@@ -70,6 +91,10 @@ subprojects {
 
     val gitUrl = "https://github.com/octopusden/octopus-external-systems-client.git"
 
+    // `maven-publish` stays applied above even for a project that is not allowlisted, so the
+    // `publish` lifecycle task still exists as a no-op and the policy check below can read
+    // `publishing` on every project. Only the publication itself is conditional.
+    if (project.path in centralPublishedProjects) {
     publishing {
         publications {
             create<MavenPublication>("maven") {
@@ -108,6 +133,7 @@ subprojects {
                 sign(publishing.publications["maven"])
             }
         }
+    }
     }
 
     idea.module {
@@ -157,5 +183,64 @@ subprojects {
 
     dependencies {
         implementation("org.jetbrains.kotlin:kotlin-stdlib")
+    }
+}
+
+// Regression guard: fails if the set of projects publishing to Maven Central drifts from the
+// allowlist above. Needed here specifically because `maven-publish` is applied to every
+// subproject unconditionally, so a new module would otherwise start publishing ~50 files to
+// Central without anyone deciding to.
+//
+// allprojects, not subprojects: the root is a publishable project like any other, and a
+// publication added there would otherwise be invisible.
+fun centralPublicationPolicyProblems(): List<String> {
+    val publishingProjects = allprojects.filter { candidate ->
+        candidate.plugins.hasPlugin("maven-publish") &&
+            candidate.extensions
+                .getByType(PublishingExtension::class.java)
+                .publications
+                .isNotEmpty()
+    }
+    val actual = publishingProjects.map { it.path }.toSet()
+    return if (actual != centralPublishedProjects) {
+        listOf(
+            "Maven Central publication set drifted.\n" +
+                "  allowlisted: ${centralPublishedProjects.sorted()}\n" +
+                "  publishing:  ${actual.sorted()}\n" +
+                "Update centralPublishedProjects in the root build script only if the change is intentional.",
+        )
+    } else {
+        emptyList()
+    }
+}
+
+// A policy violation must fail its own gate, not every Gradle invocation: throwing at
+// configuration time would break build, test, dependencies and IDE sync as well.
+val verifyCentralPublicationPolicy =
+    tasks.register("verifyCentralPublicationPolicy") {
+        group = "verification"
+        description = "Fails if the set of projects publishing to Maven Central drifts from the allowlist."
+        doLast {
+            val problems = centralPublicationPolicyProblems()
+            if (problems.isNotEmpty()) {
+                throw GradleException(problems.joinToString("\n\n"))
+            }
+            logger.lifecycle(
+                "Maven Central publication set matches the allowlist (${centralPublishedProjects.size} projects).",
+            )
+        }
+    }
+
+// Hook the task TYPE, so a concrete task such as publishMavenPublicationToMavenLocal cannot
+// bypass the guard; the aggregates are matched by name as well because `publish` is per-project
+// and `publishToSonatype` only exists with -Pnexus, so neither can be forced into existence.
+gradle.projectsEvaluated {
+    allprojects {
+        tasks.withType(AbstractPublishToMaven::class.java).configureEach {
+            dependsOn(verifyCentralPublicationPolicy)
+        }
+        tasks
+            .matching { it.name in setOf("publishToSonatype", "publish", "publishToMavenLocal") }
+            .configureEach { dependsOn(verifyCentralPublicationPolicy) }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.version=1.9.22
 junit-jupiter.version=5.9.2
 
 # Octopus quality gates (org.octopusden.octopus-quality convention plugin)
-octopus-quality.version=2.4.1
+octopus-quality.version=2.6.2
 detekt.version=1.23.8
 ktlint-gradle.version=14.0.1
 


### PR DESCRIPTION
## What

Makes publishing to Maven Central **opt-in** in this repository, stops publishing one coordinate that nothing consumes, and moves every `octopus-base` reference to v2.6.2.

Part of the organisation's Maven Central limits work (octopusden/octopus-base#163).

## Why this repository, when nothing here is oversized

Every artifact here is a thin jar; the whole repository is **under a megabyte per release**. Size is not the issue. File count is.

`measure-central-footprint.py --from-gradle`, which publishes to a throwaway local repository and reads the real coordinates back:

| | coordinates | files / release | files / month (4 releases) |
|---|---|---|---|
| before | 12 | 600 | 2 400 |
| after | 11 | 550 | 2 200 |

The organisation-wide limit is **1 000 files a month**, and the organisation currently exceeds it roughly tenfold. At 600 files per release this repository was one of the largest single contributors to that count.

## The structural problem, which is the main point of this PR

The root build applies `maven-publish` to **every** subproject and creates a publication for each, unconditionally. So any module added to `settings.gradle.kts` starts publishing ~50 files to Central the moment it exists. That was never a decision — it was the default, and it silently scales with the module count.

Publishing is now governed by an explicit **allowlist of project paths**. Adding a coordinate to Central takes an edit there; a new module defaults to unpublished, which is the safe direction. A `verifyCentralPublicationPolicy` task fails if the two ever diverge.

Paths rather than names, deliberately: a Set of names collapses two modules that share a simple name, and the root project's name is a repository-level string rather than a module name.

## Dropped: `test-client-test-commons`

Evidence that nothing consumes it, direct or transitive:

- no build file outside this repository names it — checked org-wide, not just the local checkout;
- it appears in **no published POM**. Its only users are this repository's own `testImplementation` dependencies in `bitbucket-test-client` and `gitea-test-client`, and Gradle does not carry `testImplementation` into a published POM — confirmed by fetching both POMs from repo1;
- no version catalogue aliases it, no metarunner fetches it, the README documents no install path.

That is −50 files per release, −200 a month.

## Kept, and why — including the ones that look unused

| coordinate | why it stays |
|---|---|
| `bitbucket-client`, `gitea-client` | consumed by vcs-facade |
| `teamcity-client` | consumed by CRS, reporting-service, teamcity-automation, and ORMS's ft |
| `jira-client` | consumed by ORMS; also the artifact this repository's own `check-and-register.yml` polls |
| `artifactory-client` | consumed by artifactory-automation, the build-info plugins, reporting-service |
| `confluence-client` | consumed by reporting-service |
| `client-commons` | **zero direct consumers**, but declared at `compile` scope in the published POM of every real client. Dropping it would break resolution for consumers that never name it |
| `test-client-commons` | **zero direct consumers**, but at `compile` scope in the POMs of `bitbucket-test-client` and `gitea-test-client`, which vcs-facade resolves as test dependencies |
| `bitbucket-test-client`, `gitea-test-client` | `api(...)` dependencies of vcs-facade's own `test-common`, itself used as `testImplementation`/`ftImplementation` — the legitimate published-test-helper shape |

## An open question, not a silent decision

**`sonarqube-client` is kept, but no consumer of it could be found** — nothing in the organisation resolves it, and it appears in no kept coordinate's POM. Two checks that might have explained it both came back negative: `sonar-automation` does not depend on it, and its shadow jar (which would hide the dependency, since that publication carries no dependency graph) does not bundle it.

It is nevertheless kept, because unlike internal test scaffolding a **client library for an external system** is exactly the sort of thing an out-of-organisation consumer might resolve, and absence of evidence here is not evidence of absence. **If it is genuinely unused, removing it from the allowlist saves another 50 files per release.** One line, and this PR is the place to decide it.

## Guard demonstrated failing, then passing

```
# RED 1 — a publication added to the ROOT project, which is not allowlisted
> Maven Central publication set drifted.
    allowlisted: [:artifactory-client, …, :test-client-commons]
    publishing:  [:, :artifactory-client, …, :test-client-commons]

# RED 2 — the concrete leaf task of that rogue publication
./gradlew publishRedDemoPublicationToMavenLocal
> Task :verifyCentralPublicationPolicy FAILED

# unrelated work is unaffected while the violation is present
./gradlew help -> exit 0

# GREEN — after reverting
Maven Central publication set matches the allowlist (11 projects).
```

Worth recording: the first attempt at RED was **invalid** — adding the dropped module back to the allowlist produces no drift, because that legitimately re-enables publishing. The guard was right to stay silent. The valid test is a publication that is *not* in the allowlist, which is what the run above does.

The guard hooks the `AbstractPublishToMaven` task **type** as well as the aggregates by name, so a concrete publish task cannot bypass it; and it is a task rather than a configuration-time throw, which would break `build`, `test`, `dependencies` and IDE sync the moment the set drifted.

## The octopus-base bump

All six pinned references plus `octopus-quality.version` move to v2.6.2 together, so the repository stops straddling two versions of shared CI. Nothing here trips the new release-time publication guard — every artifact is a thin jar far below the 8 MB default — so no `fat-jar-publication-allowlist` entry is needed.

## Verified locally

- `./gradlew build verifyCentralPublicationPolicy` — green, with the guard task executing.
- **Excluded, and CI must cover them:** `:teamcity-client:test`, `:bitbucket-test-client:test`, `:gitea-test-client:test`. All three need docker-compose stacks whose images are amd64-only; on an arm64 machine the first attempt spent 44 minutes pulling a 569 MB image and then failed in `composeUp`. This is unrelated to the change, which touches publication declarations and version strings only.
- The footprint measurement above, on both `origin/main` and this branch.
- The published-POM graph for all twelve coordinates, fetched from repo1.

## Not verified, and only a real release can

The release path itself. v2.6.2's release-path changes have not been exercised on a real release anywhere yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated build, quality, security, release, and merge validation processes to use the latest shared tooling.
  * Added safeguards to ensure only approved modules are published to Maven Central.
  * Added verification during publishing to detect mismatches in the approved publication list.
  * Updated the project’s quality tooling version for improved consistency across checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->