### PR TITLE
fix(ft): lower TeamCity pod CPU requests to 50m so they can be scheduled

### DIFF
--- a/teamcity-client/build.gradle.kts
+++ b/teamcity-client/build.gradle.kts
@@ -105,7 +105,12 @@ ocTemplate {
                 commonOkdParameters + mapOf(
                     "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
                     "TEAMCITY_ID" to "22",
-                    "CPU_REQUEST" to "500m",
+                    // Requests kept low, limits unchanged: on the shared test-env namespace's
+                    // 6-core nodes a half-core request per pod is too much to schedule, and both
+                    // TeamCity pods then sit in Pending until the readiness check gives up. Same
+                    // fix as octopus-teamcity-automation #67; the limit still allows the burst
+                    // these servers need while starting.
+                    "CPU_REQUEST" to "50m",
                     "CPU_LIMIT" to "2000m",
                     "MEMORY_REQUEST" to "1.5Gi",
                     "MEMORY_LIMIT" to "2Gi",
@@ -118,7 +123,7 @@ ocTemplate {
                 commonOkdParameters + mapOf(
                     "TEAMCITY_IMAGE_TAG" to project.properties["teamcity-2026.image-tag"] as String,
                     "TEAMCITY_ID" to "26",
-                    "CPU_REQUEST" to "500m",
+                    "CPU_REQUEST" to "50m",
                     "CPU_LIMIT" to "2000m",
                     "MEMORY_REQUEST" to "1.2Gi",
                     "MEMORY_LIMIT" to "2Gi",


### PR DESCRIPTION
## Symptom

The functional-test build on `main` failed at `:teamcity-client:ocCreateTeamcityServers`:

```
Pods readiness check attempts exceeded
```

Only 33 tests ran, against the usual 102 — it died during provisioning, not during testing. A readiness check exhausting its attempts is what an **unscheduled** pod looks like from outside, not a slow-starting one.

## Cause

`teamcity-client` requests **500m per pod** and starts two — a full core of *guaranteed* CPU on the shared test-env namespace's 6-core nodes. It is the only module in this repository still asking for that:

| module | CPU_REQUEST |
|---|---|
| **teamcity-client** (×2 pods) | **500m** |
| bitbucket-test-client | 10m / 150m |
| gitea-test-client | 50m |

`octopus-teamcity-automation` hit the identical symptom and fixed it identically in its **#67** — requests down to 50m, limits untouched, on DevOps' advice that a half-core request is too much to schedule a dev-environment app on those nodes. This applies the same fix here.

## Why lowering a request is safe

Requests are the **scheduling guarantee**; limits are the **ceiling**. Lowering the request changes only whether the pod can be placed. `CPU_LIMIT` stays at 2000m, so both servers can still burst during startup — which is exactly when they need it.

## Memory is deliberately untouched

The memory story runs the other way in both repositories: #136 here (June) *raised* memory for bitbucket and gitea, and teamcity-automation *raised* TeamCity's memory in its #57. Lowering `MEMORY_REQUEST` for a TeamCity server would be a different and riskier change, so it is not part of this.

## Not verified

That the pod was specifically `Pending` on CPU. Confirming that needs `oc describe pod` against the cluster while the failure is in progress, which is not available from here. The evidence is the symptom matching teamcity-automation's diagnosed case, plus this module being the clear outlier among its own siblings.

**If the FT build fails the same way after this, the next step is that `oc describe` — not another resource guess.**

## This is not a regression from the last merge

The failing revision `1866d80` contains only #144 (workflow refs, quality-plugin version, publication policy) — nothing touching OKD provisioning. The same FT config has failed intermittently before: 26.07 on a revision that passed both before and after it, and 09.07 four times in a row followed by a pass on the same commit. A rerun of the failed build is queued separately; this PR addresses the underlying scheduling pressure either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced the default CPU request for TeamCity server deployments while maintaining the existing CPU limit.
  * Improved scheduling efficiency for TeamCity 2022 and TeamCity 2026 deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->