### PR TITLE
ci: move octopus-base to v2.7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-build-and-deploy:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/octopus-external-systems-clients/jira-client/_VER_/jira-client-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -25,6 +25,6 @@ jobs:
     needs: [build, quality, security]
     runs-on: ubuntu-latest
     steps:
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.0
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.1
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.1
     with:
       java-version: '21'
       # Coverage is disabled for this repo (octopusQuality { coverage { enabled = false } }).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.1
     with:
       flow-type: hybrid
       java-version: '11'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.1
     with:
       java-version: '21'
       enable-codeql: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.version=1.9.22
 junit-jupiter.version=5.9.2
 
 # Octopus quality gates (org.octopusden.octopus-quality convention plugin)
-octopus-quality.version=2.7.0
+octopus-quality.version=2.7.1
 detekt.version=1.23.8
 ktlint-gradle.version=14.0.1
 


### PR DESCRIPTION
## What

Moves every pinned `octopus-base` reference from **v2.7.0** to **v2.7.1**, plus the
`octopus-quality` convention-plugin version so this repository does not straddle two versions of
shared CI.

## Why

v2.7.1 fixes a read-after-write race in the release workflows. A release could publish its
artifacts, create its tag, and then fail with:

```
tag vX.Y.Z doesn't exist in the repo ..., aborting due to --verify-tag flag
```

leaving a **half-release**: artifacts published and immutable, tag created at the right commit, no
GitHub release, and registration skipped. It cannot be recovered by re-dispatching the release,
because the version is already published — the recovery is GitHub's *re-run failed jobs* on the
same run, which adopts the existing tag and attaches the release.

`gh release create --verify-tag` resolves the tag through its own GraphQL
`repository.ref(qualifiedName:)` lookup, and that read can miss a ref created milliseconds
earlier. v2.7.1 waits for exactly that lookup to see the tag, on both the fresh-tag and the
tag-adoption path, in the Gradle and Maven release workflows.

Three occurrences are on record, **two of them on v2.7.0 itself**, in two different repositories:
api-gateway v2.0.19, dms-ui v3.0.11 (never repaired), dms-ui v3.0.12. Every repository pinned at
v2.6.2 or later is exposed, which is why this is being rolled out rather than left to the next
release.

Details: octopusden/octopus-base#194.

## Scope

Mechanical. v2.7.1 contains only that fix and its tests, so nothing about this repository's build,
publication set or quality gates changes.

Comments in `build.gradle.kts` that read "from octopus-base v2.7.0" are deliberately left alone:
they record **when the shared publication guard was introduced**, which this bump does not change.
Only text naming the version actually pinned was updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project automation and quality tooling to version 2.7.1.
  - Improved consistency across build, release, validation, merge, and security checks.
  - Ensured the project’s quality configuration aligns with the latest supported tooling revision.
- **Release Process**
  - Updated release automation to use the latest workflow version, supporting more reliable builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->