### PR TITLE
Add archived attribute in Bitbucket repository

### DIFF
--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketRepository.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketRepository.kt
@@ -12,4 +12,5 @@ class BitbucketRepository
         val slug: String,
         val links: BitbucketLinks,
         val project: BitbucketProject,
+        val archived: Boolean = false,
     )

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketUpdateRepository.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketUpdateRepository.kt
@@ -9,4 +9,5 @@ class BitbucketUpdateRepository
     constructor(
         val name: String,
         val project: BitbucketProject,
+        val archived: Boolean = false,
     )

--- a/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketUpdateRepository.kt
+++ b/bitbucket-client/src/main/kotlin/org/octopusden/octopus/infrastructure/bitbucket/client/dto/BitbucketUpdateRepository.kt
@@ -2,12 +2,14 @@ package org.octopusden.octopus.infrastructure.bitbucket.client.dto
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 class BitbucketUpdateRepository
     @JsonCreator
     constructor(
         val name: String,
         val project: BitbucketProject,
-        val archived: Boolean = false,
+        val archived: Boolean? = null,
     )

--- a/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
+++ b/bitbucket-test-client/src/test/kotlin/org/octopusden/octopus/infastructure/bitbucket/test/BitbucketTestClientTest.kt
@@ -15,6 +15,7 @@ import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketDelet
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketDeletePullRequest
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketPullRequest
 import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketTag
+import org.octopusden.octopus.infrastructure.bitbucket.client.dto.BitbucketUpdateRepository
 import org.octopusden.octopus.infrastructure.bitbucket.client.exception.NotFoundException
 import org.octopusden.octopus.infrastructure.bitbucket.client.getBranch
 import org.octopusden.octopus.infrastructure.bitbucket.client.getCommit
@@ -88,6 +89,38 @@ class BitbucketTestClientTest :
             title,
             description,
         ).toTestPullRequest()
+
+    @Test
+    fun testGetRepository() {
+        testClient.commit(
+            NewChangeSet(
+                "${BaseTestClient.DEFAULT_BRANCH} commit",
+                vcsUrl,
+                BaseTestClient.DEFAULT_BRANCH,
+            ),
+        )
+        val repository = client.getRepository(PROJECT, REPOSITORY)
+        Assertions.assertEquals(REPOSITORY, repository.slug)
+        Assertions.assertFalse(repository.archived)
+    }
+
+    @Test
+    fun testArchiveRepository() {
+        testClient.commit(
+            NewChangeSet(
+                "${BaseTestClient.DEFAULT_BRANCH} commit",
+                vcsUrl,
+                BaseTestClient.DEFAULT_BRANCH,
+            ),
+        )
+        val repository = client.getRepository(PROJECT, REPOSITORY)
+        client.updateRepository(
+            PROJECT,
+            REPOSITORY,
+            BitbucketUpdateRepository(repository.name, repository.project, archived = true),
+        )
+        Assertions.assertTrue(client.getRepository(PROJECT, REPOSITORY).archived)
+    }
 
     @Test
     fun testGetRepositoryFiles() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository information now includes whether a repository is archived.
  * Repositories default to an active (not archived) status when this information is unavailable.
  * Repositories can be archived through update operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->